### PR TITLE
Fixed filtering problems & added tests

### DIFF
--- a/papiea-engine/__tests__/database_tests/database_mongo.test.ts
+++ b/papiea-engine/__tests__/database_tests/database_mongo.test.ts
@@ -29,6 +29,7 @@ const mongoPort = process.env.MONGO_PORT || '27017';
 describe("MongoDb tests", () => {
     const connection: MongoConnection = new MongoConnection(`mongodb://${mongoHost}:${mongoPort}`, process.env.MONGO_DB || 'papiea');
     const logger = LoggerFactory.makeLogger({level: 'info'});
+    const exact_match = false
 
     beforeEach(() => {
         jest.setTimeout(50000);
@@ -128,14 +129,14 @@ describe("MongoDb tests", () => {
     test("List Specs", async () => {
         expect.assertions(1);
         const specDb: Spec_DB = await connection.get_spec_db(logger);
-        const res = await specDb.list_specs({ metadata: { "kind": "test" } });
+        const res = await specDb.list_specs({ metadata: { "kind": "test" } }, exact_match);
         expect(res.length).toBeGreaterThanOrEqual(1);
     });
 
     test("List Specs - check spec data", async () => {
         expect.assertions(4);
         const specDb: Spec_DB = await connection.get_spec_db(logger);
-        const res = await specDb.list_specs({ metadata: { "kind": "test" }, spec: { "a": "A1" } });
+        const res = await specDb.list_specs({ metadata: { "kind": "test" }, spec: { "a": "A1" } }, exact_match);
         expect(res).not.toBeNull();
         expect(res[0]).not.toBeNull();
         expect(res.length).toBeGreaterThanOrEqual(1);
@@ -202,14 +203,14 @@ describe("MongoDb tests", () => {
     test("List Statuses", async () => {
         expect.assertions(1);
         const statusDb: Status_DB = await connection.get_status_db(logger);
-        const res = await statusDb.list_status({ metadata: { "kind": "test" } });
+        const res = await statusDb.list_status({ metadata: { "kind": "test" } }, exact_match);
         expect(res.length).toBeGreaterThanOrEqual(1);
     });
 
     test("List Statuses - check status data", async () => {
         expect.assertions(3);
         const statusDb: Status_DB = await connection.get_status_db(logger);
-        const res = await statusDb.list_status({ metadata: { "kind": "test" }, status: { a: "A1" } });
+        const res = await statusDb.list_status({ metadata: { "kind": "test" }, status: { a: "A1" } }, exact_match);
         expect(res.length).toBeGreaterThanOrEqual(1);
         expect(res[0]).not.toBeNull();
         // @ts-ignore

--- a/papiea-engine/__tests__/entity_tests/entity_api.test.ts
+++ b/papiea-engine/__tests__/entity_tests/entity_api.test.ts
@@ -193,7 +193,9 @@ describe("Entity API tests", () => {
         let res = await entityApi.post(`${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
             spec: {
                 x: 10,
-                "v.e": 12
+                v: {
+                    e: 12
+                }
             }
         });
         expect(res.data.results.length).toBeGreaterThanOrEqual(1);
@@ -215,7 +217,7 @@ describe("Entity API tests", () => {
             expect(entity.spec.x).toEqual(10);
             expect(entity.spec.v.e).toEqual(12);
         });
-        res = await entityApi.post(`${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
+        res = await entityApi.post(`${ providerPrefix }/${ providerVersion }/${ kind_name }/filter?exact=true`, {
             spec: {
                 x: 10,
                 v: {
@@ -228,7 +230,9 @@ describe("Entity API tests", () => {
         res = await entityApi.post(`${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
             status: {
                 x: 10,
-                "v.e": 12
+                v: {
+                    e: 12
+                }
             }
         });
         expect(res.data.results.length).toBeGreaterThanOrEqual(1);
@@ -236,9 +240,10 @@ describe("Entity API tests", () => {
             expect(entity.status.x).toEqual(10);
             expect(entity.status.v.e).toEqual(12);
         });
-        res = await entityApi.post(`${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
+        res = await entityApi.post(`${ providerPrefix }/${ providerVersion }/${ kind_name }/filter?exact=true`, {
             status: {
                 x: 10,
+                y: 11,
                 v: {
                     e: 12,
                     d: 13
@@ -250,7 +255,7 @@ describe("Entity API tests", () => {
             expect(entity.status.x).toEqual(10);
             expect(entity.status.v.e).toEqual(12);
         });
-        res = await entityApi.post(`${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
+        res = await entityApi.post(`${ providerPrefix }/${ providerVersion }/${ kind_name }/filter?exact=true`, {
             status: {
                 x: 10,
                 v: {
@@ -263,11 +268,19 @@ describe("Entity API tests", () => {
         res = await entityApi.post(`${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
             spec: {
                 x: 10,
-                "v.e": 12
+                y: 11,
+                v: {
+                    e: 12,
+                    d: 13
+                },
             },
             status: {
                 x: 10,
-                "v.e": 12
+                y: 11,
+                v: {
+                    e: 12,
+                    d: 13
+                },
             }
         });
         expect(res.data.results.length).toBeGreaterThanOrEqual(1);
@@ -423,7 +436,6 @@ describe("Entity API tests", () => {
                 }
             });
         } catch (e) {
-            console.log(`Got error: ${JSON.stringify(e.response.data)}`)
             expect(e.response.status).toEqual(409)
             expect(e.response.data.error.message).toEqual(`Conflicting Entity: ${entity_uuid} has version ${1}`)
         }

--- a/papiea-engine/__tests__/entity_tests/filtering.test.ts
+++ b/papiea-engine/__tests__/entity_tests/filtering.test.ts
@@ -1,0 +1,177 @@
+import { ProviderBuilder } from "../test_data_factory";
+import axios from "axios";
+import { plural } from "pluralize"
+import { IntentfulBehaviour, SpecOnlyEntityKind } from "papiea-core"
+
+declare var process: {
+    env: {
+        SERVER_PORT: string,
+        PAPIEA_ADMIN_S2S_KEY: string
+    }
+};
+const serverPort = parseInt(process.env.SERVER_PORT || '3000');
+const adminKey = process.env.PAPIEA_ADMIN_S2S_KEY || '';
+
+const entityApi = axios.create({
+    baseURL: `http://127.0.0.1:${serverPort}/services`,
+    timeout: 10000,
+    headers: { 'Content-Type': 'application/json' }
+});
+
+const providerApi = axios.create({
+    baseURL: `http://127.0.0.1:${serverPort}/provider/`,
+    timeout: 1000,
+    headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${adminKey}`
+    }
+});
+
+describe("Filtering tests", () => {
+    const providerPrefix = "test_filtering";
+    const providerVersion = "0.1.0";
+    const kind_name: string = "F"
+    const kind_structure = {
+        F: {
+            type: "object",
+            "x-papiea-entity": "spec-only",
+            properties: {
+                a: {
+                    type: "string"
+                },
+                b: {
+                    type: "object",
+                    properties: {
+                        x: {
+                            type: "string"
+                        },
+                        y: {
+                            type: "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    const kind: SpecOnlyEntityKind = {
+        name: kind_name,
+        name_plural: plural(kind_name),
+        kind_structure: kind_structure,
+        intentful_signatures: [],
+        dependency_tree: new Map(),
+        kind_procedures: {},
+        entity_procedures: {},
+        differ: undefined,
+        intentful_behaviour: IntentfulBehaviour.SpecOnly
+    };
+
+    beforeAll(async () => {
+        const provider = new ProviderBuilder(providerPrefix).withVersion(providerVersion).withKinds([kind]).build();
+        await providerApi.post('/', provider);
+    });
+
+    afterAll(async () => {
+        jest.setTimeout(5000);
+        await providerApi.delete(`${providerPrefix}/${providerVersion}`);
+    });
+
+    let uuids: string[] = [];
+    test("Filter with direct and reverse order of nested spec fields", async () => {
+        expect.assertions(2);
+        const entity = await entityApi.post(`/${ providerPrefix }/${ providerVersion }/${ kind_name }`, {
+            spec: {
+                a: "a",
+                b: {
+                    x: "x",
+                    y: "y"
+                }
+            }
+        });
+        try {
+            let { data: { results } } = await entityApi.post(`/${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
+                spec: {
+                    a: "a",
+                    b: {
+                        x: "x",
+                        y: "y"
+                    }
+                }
+            })
+            expect(results.length).toEqual(1)
+            let swapped_res = await entityApi.post(`/${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
+                spec: {
+                    a: "a",
+                    b: {
+                        y: "y",
+                        x: "x"
+                    }
+                }
+            })
+            expect(swapped_res.data.results.length).toEqual(1)
+        } finally {
+            await entityApi.delete(`/${ providerPrefix }/${ providerVersion }/${ kind_name }/${ entity.data.metadata.uuid }`)
+        }
+    }, 5000);
+
+    test("Filter with direct and reverse order of nested status fields", async () => {
+        expect.assertions(2);
+        const entity = await entityApi.post(`/${ providerPrefix }/${ providerVersion }/${ kind_name }`, {
+            spec: {
+                a: "a",
+                b: {
+                    x: "x",
+                    y: "y"
+                }
+            }
+        });
+        try {
+            let { data: { results } } = await entityApi.post(`/${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
+                status: {
+                    a: "a",
+                    b: {
+                        x: "x",
+                        y: "y"
+                    }
+                }
+            })
+            expect(results.length).toEqual(1)
+            let swapped_res = await entityApi.post(`/${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
+                status: {
+                    a: "a",
+                    b: {
+                        y: "y",
+                        x: "x"
+                    }
+                }
+            })
+            expect(swapped_res.data.results.length).toEqual(1)
+        } finally {
+            await entityApi.delete(`/${ providerPrefix }/${ providerVersion }/${ kind_name }/${ entity.data.metadata.uuid }`)
+        }
+    }, 5000);
+
+    test("Filter with direct and reverse order of partial nested spec fields", async () => {
+        expect.assertions(1);
+        const entity = await entityApi.post(`/${ providerPrefix }/${ providerVersion }/${ kind_name }`, {
+            spec: {
+                a: "a",
+                b: {
+                    x: "x",
+                    y: "y"
+                }
+            }
+        });
+        try {
+            let { data: { results } } = await entityApi.post(`/${ providerPrefix }/${ providerVersion }/${ kind_name }/filter`, {
+                status: {
+                    b: {
+                        x: "x",
+                    }
+                }
+            })
+            expect(results.length).toEqual(1)
+        } finally {
+            await entityApi.delete(`/${ providerPrefix }/${ providerVersion }/${ kind_name }/${ entity.data.metadata.uuid }`)
+        }
+    }, 5000);
+});

--- a/papiea-engine/src/databases/spec_db_interface.ts
+++ b/papiea-engine/src/databases/spec_db_interface.ts
@@ -33,7 +33,7 @@ export interface Spec_DB {
     // We could come up with command such as greater-than etc at some
     // later point, or we could use a similar dsl to mongodb search
     // dsl.
-    list_specs(fields_map: any, sortParams?: SortParams): Promise<([Metadata, Spec])[]>;
+    list_specs(fields_map: any, exact_match: boolean, sortParams?: SortParams): Promise<([Metadata, Spec])[]>;
 
     list_specs_in(filter_list: any[], field_name?: string): Promise<([Metadata, Spec])[]>
 

--- a/papiea-engine/src/databases/spec_db_mongo.ts
+++ b/papiea-engine/src/databases/spec_db_mongo.ts
@@ -7,7 +7,8 @@ import { Entity_Reference, Metadata, Spec, Entity } from "papiea-core";
 import { SortParams } from "../entity/entity_api_impl";
 import { Logger } from "papiea-backend-utils";
 import { IntentfulKindReference } from "./provider_db_mongo";
-import { deepMerge } from "../utils/utils"
+import { deepMerge, isEmpty } from "../utils/utils"
+import { build_filter_query } from "./utils/filtering"
 
 export class Spec_DB_Mongo implements Spec_DB {
     collection: Collection;
@@ -97,19 +98,8 @@ export class Spec_DB_Mongo implements Spec_DB {
         });
     }
 
-    async list_specs(fields_map: any, sortParams?: SortParams): Promise<([Metadata, Spec])[]> {
-        let filter: any = {};
-        filter["metadata.deleted_at"] = datestringToFilter(fields_map?.metadata?.deleted_at);
-        for (let key in fields_map.metadata) {
-            if (key === "deleted_at")
-                continue;
-            filter["metadata." + key] = fields_map.metadata[key];
-        }
-        filter = deepMerge(
-            filter,
-            encode({spec: fields_map.spec}),
-            encode({status: fields_map.status})
-        )
+    async list_specs(fields_map: any, exact_match: boolean, sortParams?: SortParams): Promise<([Metadata, Spec])[]> {
+        const filter = build_filter_query(fields_map, exact_match)
         let result: any[];
         if (sortParams) {
             result = await this.collection.find(filter).sort(sortParams).toArray();

--- a/papiea-engine/src/databases/status_db_interface.ts
+++ b/papiea-engine/src/databases/status_db_interface.ts
@@ -26,7 +26,7 @@ export interface Status_DB {
     // We could come up with command such as greater-than etc at some
     // later point, or we could use a similar dsl to mongodb search
     // dsl.
-    list_status(fields_map: any, sortParams?: SortParams): Promise<([Metadata, Status])[]>;
+    list_status(fields_map: any, exact_match: boolean, sortParams?: SortParams): Promise<([Metadata, Status])[]>;
 
     list_status_in(filter_list: any[], field_name?: string): Promise<([Metadata, Status])[]>
 

--- a/papiea-engine/src/databases/utils/filtering.ts
+++ b/papiea-engine/src/databases/utils/filtering.ts
@@ -1,0 +1,43 @@
+import { deepMerge, isEmpty } from "../../utils/utils"
+import { encode } from "mongo-dot-notation-tool"
+import { datestringToFilter } from "./date"
+
+export function build_filter_query(fields_map: any, exact_match: boolean) {
+    let filter: any = {}
+    if (fields_map.metadata && fields_map.metadata.deleted_at) {
+        filter["metadata.deleted_at"] = datestringToFilter(fields_map.metadata.deleted_at);
+    } else {
+        filter["metadata.deleted_at"] = null
+    }
+
+    for (let key in fields_map.metadata) {
+        if (key === "deleted_at")
+            continue;
+        filter["metadata." + key] = fields_map.metadata[key];
+    }
+    if (exact_match) {
+        if (!isEmpty(fields_map.spec)) {
+            filter.spec = fields_map.spec
+        }
+        if (!isEmpty(fields_map.status)) {
+            filter.status = fields_map.status
+        }
+    } else if (fields_map.spec && fields_map.status) {
+        filter = deepMerge(
+            filter,
+            encode({spec: fields_map.spec}),
+            encode({status: fields_map.status})
+        )
+    } else if (fields_map.spec) {
+        filter = deepMerge(
+            filter,
+            encode({spec: fields_map.spec}),
+        )
+    } else if (fields_map.status) {
+        filter = deepMerge(
+            filter,
+            encode({status: fields_map.status})
+        )
+    }
+    return filter
+}

--- a/papiea-engine/src/entity/entity_api_impl.ts
+++ b/papiea-engine/src/entity/entity_api_impl.ts
@@ -209,12 +209,6 @@ export class Entity_API_Impl implements Entity_API {
                 }, {
                     headers: user
                 });
-            console.log("HERE")
-            console.log(data)
-            console.log(Object.values(procedure.result)[0])
-            console.log(Object.keys(procedure.result)[0])
-            console.log(procedure.name)
-
             this.validator.validate(data, Object.values(procedure.result)[0], schemas,
                 provider.allowExtraProps, Object.keys(procedure.argument)[0], procedure_name);
             return data;

--- a/papiea-engine/src/entity/entity_api_impl.ts
+++ b/papiea-engine/src/entity/entity_api_impl.ts
@@ -109,16 +109,16 @@ export class Entity_API_Impl implements Entity_API {
         return [metadata, status];
     }
 
-    async filter_entity_spec(user: UserAuthInfo, kind_name: string, fields: any, sortParams?: SortParams): Promise<[Metadata, Spec][]> {
+    async filter_entity_spec(user: UserAuthInfo, kind_name: string, fields: any, exact_match: boolean, sortParams?: SortParams): Promise<[Metadata, Spec][]> {
         fields.metadata.kind = kind_name;
-        const res = await this.spec_db.list_specs(fields, sortParams);
+        const res = await this.spec_db.list_specs(fields, exact_match, sortParams);
         const filteredRes = await this.authorizer.filter(user, res, Action.Read, x => { return { "metadata": x[0] } });
         return filteredRes;
     }
 
-    async filter_entity_status(user: UserAuthInfo, kind_name: string, fields: any, sortParams?: SortParams): Promise<[Metadata, Status][]> {
+    async filter_entity_status(user: UserAuthInfo, kind_name: string, fields: any, exact_match: boolean, sortParams?: SortParams): Promise<[Metadata, Status][]> {
         fields.metadata.kind = kind_name;
-        const res = await this.status_db.list_status(fields, sortParams);
+        const res = await this.status_db.list_status(fields, exact_match, sortParams);
         const filteredRes = await this.authorizer.filter(user, res, Action.Read, x => { return { "metadata": x[0] } });
         return filteredRes;
     }

--- a/papiea-engine/src/entity/entity_api_interface.ts
+++ b/papiea-engine/src/entity/entity_api_interface.ts
@@ -14,9 +14,9 @@ export interface Entity_API {
 
     filter_intentful_task(user: UserAuthInfo, fields: any, sortParams?: SortParams): Promise<Partial<IntentfulTask>[]>
 
-    filter_entity_spec(user: UserAuthInfo, kind_name: string, fields: any, sortParams?: SortParams): Promise<[Metadata, Spec][]>
+    filter_entity_spec(user: UserAuthInfo, kind_name: string, fields: any, exact_match: boolean, sortParams?: SortParams): Promise<[Metadata, Spec][]>
 
-    filter_entity_status(user: UserAuthInfo, kind_name: string, fields: any, sortParams?: SortParams): Promise<[Metadata, Status][]>
+    filter_entity_status(user: UserAuthInfo, kind_name: string, fields: any, exact_match: boolean, sortParams?: SortParams): Promise<[Metadata, Status][]>
 
     update_entity_spec(user: UserAuthInfo, uuid: uuid4, prefix: string, spec_version: number, extension: {[key: string]: any}, kind_name: string, version: Version, spec_description: Spec): Promise<IntentfulTask | null>
 

--- a/papiea-engine/src/errors/procedure_invocation_error.ts
+++ b/papiea-engine/src/errors/procedure_invocation_error.ts
@@ -17,7 +17,7 @@ export class ProcedureInvocationError extends Error {
     static fromError(err: ValidationError, status?: number): ProcedureInvocationError
     static fromError(err: Error, status?: number): ProcedureInvocationError {
         if (isAxiosError(err)) {
-            console.log(err)
+            //console.log("Axios Error on procedure invocation:", err) 
             return new ProcedureInvocationError([{
                 message: err.response?.data.message,
                 errors: err.response?.data.errors,

--- a/papiea-engine/src/utils/utils.ts
+++ b/papiea-engine/src/utils/utils.ts
@@ -101,3 +101,26 @@ export function getRandomInt(min: number, max: number) {
 export function isAxiosError(e: Error): e is AxiosError {
     return e.hasOwnProperty("response");
 }
+
+export function isObject(item: any): item is Object {
+    return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+
+export function deepMerge(target: any, ...sources: any[]): any {
+    if (!sources.length) return target;
+    const source = sources.shift();
+
+    if (isObject(target) && isObject(source)) {
+        for (const key in source) {
+            if (isObject(source[key])) {
+                if (!target[key]) Object.assign(target, { [key]: {} });
+                deepMerge(target[key], source[key]);
+            } else {
+                Object.assign(target, { [key]: source[key] });
+            }
+        }
+    }
+
+    return deepMerge(target, ...sources);
+}


### PR DESCRIPTION
resolves #407 

Added `/filter?exact=true` to preserve original exact filtering capabilities. By default this is false and asides from field order issues, adds ability to filter not necessarily specifying all fields in spec/status. E.g.

 ```
{
   "spec": {
     "state": "free",
     "type": {
       "kind": "machine-type",
       "uuid": "cb498080-715b-405e-8071-7e2398c2bf0f"
     }
   }
}
```
now also can be filtered by:
```
{
   "spec": {
     "type": {
       "kind": "machine-type",
     }
   }
}
```