### PR TITLE
Added tests & added error message in case of failed status watcher

### DIFF
--- a/papiea-engine/src/intentful_core/intentful_strategies/differ_intentful_strategy.ts
+++ b/papiea-engine/src/intentful_core/intentful_strategies/differ_intentful_strategy.ts
@@ -60,8 +60,10 @@ export class DifferIntentfulStrategy extends IntentfulStrategy {
         try {
             await this.update_entity(metadata, spec)
         } catch (e) {
+            watcher.times_failed++
+            watcher.last_handler_error = e.message
             watcher.status = IntentfulStatus.Failed
-            await this.intentWatcherDb.update_watcher(watcher.uuid, { status: watcher.status })
+            await this.intentWatcherDb.update_watcher(watcher.uuid, { ...watcher })
         }
         return watcher
     }


### PR DESCRIPTION
resolves #469 

@joshua-berry-ntnx I couldn't find the race condition described in the issue and added a few tests for concurrent and serial updates. A few words though:
1) `Differ` entities always return Watcher as a response to any PUT request (Failed one in case of CAS problem)
2) All the other entities return `409 Conflicting Entity` Error in case of CAS problem

Thus for `Differ` entities I added error message in case of CAS fail to signify what is the problem exactly.