### PR TITLE
Conflicting entities now always throw the exception

### DIFF
--- a/papiea-engine/src/intentful_core/intentful_strategies/differ_intentful_strategy.ts
+++ b/papiea-engine/src/intentful_core/intentful_strategies/differ_intentful_strategy.ts
@@ -64,6 +64,7 @@ export class DifferIntentfulStrategy extends IntentfulStrategy {
             watcher.last_handler_error = e.message
             watcher.status = IntentfulStatus.Failed
             await this.intentWatcherDb.update_watcher(watcher.uuid, { ...watcher })
+            throw e
         }
         return watcher
     }


### PR DESCRIPTION
@shlomi-nx now that all the entities throw, what is the use for `Failed` status on IntentWatcher? I've left it just in case we would like to have history of intent changes illustrated by watchers but still