### PR TITLE
issues-468: remove status-only fields from required sections of spec api

### DIFF
--- a/papiea-engine/__tests__/docs_tests/api_docs.test.ts
+++ b/papiea-engine/__tests__/docs_tests/api_docs.test.ts
@@ -294,27 +294,27 @@ describe("API docs test entity", () => {
     });
 
     test("Provider with procedures generates correct openAPI removing all variables with 'x-papiea' - 'status_only' from properties and required of a spec", async () => {
-        expect.hasAssertions();
-        const provider = new ProviderBuilder("provider_include_all_props").withVersion("0.1.0").withKinds([getSpecOnlyKind()]).build();
-        const providerDbMock = new Provider_DB_Mock(provider);
-        const apiDocsGenerator = new ApiDocsGenerator(providerDbMock);
-        const kind_name = provider.kinds[0].name;
-        const structure = provider.kinds[0].kind_structure[kind_name];
+        expect.hasAssertions()
+        const provider = new ProviderBuilder("provider_include_all_props").withVersion("0.1.0").withKinds([getSpecOnlyKind()]).build()
+        const providerDbMock = new Provider_DB_Mock(provider)
+        const apiDocsGenerator = new ApiDocsGenerator(providerDbMock)
+        const kind_name = provider.kinds[0].name
+        const structure = provider.kinds[0].kind_structure[kind_name]
 
         // add 'z' to required field, so that we check it gets removed from required and fields
-        structure.required.push("z");
+        structure.required.push("z")
 
         // add required fields to v that are marked as status-only so that we check recursive deletion works
-        structure.properties.v.required = ["h"];
-        structure.properties.v.properties["h"] = {"type": "number", "x-papiea": "status-only"};
+        structure.properties.v.required = ["h"]
+        structure.properties.v.properties["h"] = {"type": "number", "x-papiea": "status-only"}
 
         // set x to spec-only to see that the implementation doesn't remove it from the required fields
-        structure.properties.x["x-papiea"] = "spec-only";
+        structure.properties.x["x-papiea"] = "spec-only"
 
-        const apiDoc = await apiDocsGenerator.getApiDocs(providerDbMock.provider);
-        const entityName = kind_name + "-Spec";
-        expect(Object.keys(apiDoc.components.schemas)).toContain(entityName);
-        const entitySchema = apiDoc.components.schemas[entityName];
+        const apiDoc = await apiDocsGenerator.getApiDocs(providerDbMock.provider)
+        const entityName = kind_name + "-Spec"
+        expect(Object.keys(apiDoc.components.schemas)).toContain(entityName)
+        const entitySchema = apiDoc.components.schemas[entityName]
         expect(entitySchema).toEqual({
             "type": "object",
             "title": "X\/Y Location",
@@ -341,8 +341,8 @@ describe("API docs test entity", () => {
                     }
                 }
             }
-        });
-    });
+        })
+    })
 
     test("Provider with procedures that have no validation generate correct open api docs", async () => {
         expect.hasAssertions();

--- a/papiea-engine/__tests__/docs_tests/api_docs.test.ts
+++ b/papiea-engine/__tests__/docs_tests/api_docs.test.ts
@@ -308,6 +308,9 @@ describe("API docs test entity", () => {
         structure.properties.v.required = ["h"];
         structure.properties.v.properties["h"] = {"type": "number", "x-papiea": "status-only"};
 
+        // set x to spec-only to see that the implementation doesn't remove it from the required fields
+        structure.properties.x["x-papiea"] = "spec-only";
+
         const apiDoc = await apiDocsGenerator.getApiDocs(providerDbMock.provider);
         const entityName = kind_name + "-Spec";
         expect(Object.keys(apiDoc.components.schemas)).toContain(entityName);
@@ -320,7 +323,8 @@ describe("API docs test entity", () => {
             "required": ["x", "y"],
             "properties": {
                 "x": {
-                    "type": "number"
+                    "type": "number",
+                    "x-papiea": "spec-only"
                 },
                 "y": {
                     "type": "number"

--- a/papiea-engine/__tests__/docs_tests/api_docs.test.ts
+++ b/papiea-engine/__tests__/docs_tests/api_docs.test.ts
@@ -2,7 +2,7 @@ import "jest"
 import { writeFileSync, unlinkSync } from "fs";
 import { validate } from "swagger-parser";
 import axios from "axios"
-import { loadYamlFromTestFactoryDir, ProviderBuilder } from "../test_data_factory";
+import { getSpecOnlyKind, loadYamlFromTestFactoryDir, ProviderBuilder } from "../test_data_factory";
 import { Provider_DB } from "../../src/databases/provider_db_interface";
 import { Provider, Version, Procedural_Signature, Procedural_Execution_Strategy, Kind } from "papiea-core";
 import ApiDocsGenerator from "../../src/api_docs/api_docs_generator";
@@ -276,6 +276,53 @@ describe("API docs test entity", () => {
                     "type": "number"
                 },
                 "z": {
+                    "type": "number"
+                },
+                "v": {
+                    "type": "object",
+                    "properties": {
+                        "d": {
+                            "type": "number"
+                        },
+                        "e": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        });
+    });
+
+    test("Provider with procedures generates correct openAPI removing all variables with 'x-papiea' - 'status_only' from properties and required of a spec", async () => {
+        expect.hasAssertions();
+        const provider = new ProviderBuilder("provider_include_all_props").withVersion("0.1.0").withKinds([getSpecOnlyKind()]).build();
+        const providerDbMock = new Provider_DB_Mock(provider);
+        const apiDocsGenerator = new ApiDocsGenerator(providerDbMock);
+        const kind_name = provider.kinds[0].name;
+        const structure = provider.kinds[0].kind_structure[kind_name];
+
+        // add 'z' to required field, so that we check it gets removed from required and fields
+        structure.required.push("z");
+
+        // add required fields to v that are marked as status-only so that we check recursive deletion works
+        structure.properties.v.required = ["h"];
+        structure.properties.v.properties["h"] = {"type": "number", "x-papiea": "status-only"};
+
+        const apiDoc = await apiDocsGenerator.getApiDocs(providerDbMock.provider);
+        const entityName = kind_name + "-Spec";
+        expect(Object.keys(apiDoc.components.schemas)).toContain(entityName);
+        const entitySchema = apiDoc.components.schemas[entityName];
+        expect(entitySchema).toEqual({
+            "type": "object",
+            "title": "X\/Y Location",
+            "description": "Stores an XY location of something",
+            "x-papiea-entity": "spec-only",
+            "required": ["x", "y"],
+            "properties": {
+                "x": {
+                    "type": "number"
+                },
+                "y": {
                     "type": "number"
                 },
                 "v": {

--- a/papiea-engine/__tests__/docs_tests/api_docs.test.ts
+++ b/papiea-engine/__tests__/docs_tests/api_docs.test.ts
@@ -308,9 +308,6 @@ describe("API docs test entity", () => {
         structure.properties.v.required = ["h"]
         structure.properties.v.properties["h"] = {"type": "number", "x-papiea": "status-only"}
 
-        // set x to spec-only to see that the implementation doesn't remove it from the required fields
-        structure.properties.x["x-papiea"] = "spec-only"
-
         const apiDoc = await apiDocsGenerator.getApiDocs(providerDbMock.provider)
         const entityName = kind_name + "-Spec"
         expect(Object.keys(apiDoc.components.schemas)).toContain(entityName)
@@ -323,8 +320,7 @@ describe("API docs test entity", () => {
             "required": ["x", "y"],
             "properties": {
                 "x": {
-                    "type": "number",
-                    "x-papiea": "spec-only"
+                    "type": "number"
                 },
                 "y": {
                     "type": "number"

--- a/papiea-engine/__tests__/docs_tests/api_docs.test.ts
+++ b/papiea-engine/__tests__/docs_tests/api_docs.test.ts
@@ -284,7 +284,7 @@ describe("API docs test entity", () => {
 
     test("Provider with procedures generates correct openAPI removing all variables with 'x-papiea' - 'status_only' from properties and required of a spec", async () => {
         expect.hasAssertions()
-        const provider = new ProviderBuilder("provider_include_all_props").withVersion("0.1.0").withKinds([getSpecOnlyKind()]).build()
+        const provider = new ProviderBuilder("provider_include_all_props").withVersion("0.1.0").withKinds([getBasicKind()]).build()
         const providerDbMock = new Provider_DB_Mock(provider)
         const apiDocsGenerator = new ApiDocsGenerator(providerDbMock)
         const kind_name = provider.kinds[0].name
@@ -305,7 +305,7 @@ describe("API docs test entity", () => {
             "type": "object",
             "title": "X\/Y Location",
             "description": "Stores an XY location of something",
-            "x-papiea-entity": "spec-only",
+            "x-papiea-entity": "basic",
             "required": ["x", "y"],
             "properties": {
                 "x": {

--- a/papiea-engine/__tests__/provider_tests/provider_api.test.ts
+++ b/papiea-engine/__tests__/provider_tests/provider_api.test.ts
@@ -2,7 +2,12 @@ import "jest"
 import axios from "axios"
 import {
     getClusterKind,
-    getClusterKindWithNullableFields, getSpecOnlyArrayKind,
+    getClusterKindWithNullableFields,
+    getSpecOnlyArrayKind,
+    getSpecOnlyKindByDescription,
+    getSpecOnlyKindDescription,
+    getSpecOnlyKindDescriptionWithSpecOnlyFields,
+    getSpecOnlyKindDescriptionWithStatusOnlyFields,
     loadYamlFromTestFactoryDir,
     ProviderBuilder
 } from "../test_data_factory"
@@ -61,6 +66,48 @@ describe("Provider API tests", () => {
     test("Register provider with malformed kind procedures", done => {
         const provider: any = { version: providerVersion, prefix: providerPrefix, kinds: [ {kind_procedures: {"argument": {malformed_field: "test" }}}], procedures: {}, extension_structure: {}, allowExtraProps: false };
         providerApi.post('/', provider).then(() => done.fail()).catch(() => done());
+    });
+
+    test("Register provider with spec only kind structure with status only fields", done => {
+        const desc = getSpecOnlyKindDescriptionWithStatusOnlyFields()
+        const kind = getSpecOnlyKindByDescription(desc)
+        const provider: any = {
+            version: providerVersion,
+            prefix: providerPrefix,
+            kinds: [kind],
+            procedures: {},
+            extension_structure: {},
+            allowExtraProps: false
+        };
+        providerApi.post('/', provider).then((e) => done.fail()).catch(() => done());
+    });
+
+    test("Register provider with spec only kind structure with spec only fields", done => {
+        const desc = getSpecOnlyKindDescriptionWithSpecOnlyFields()
+        const kind = getSpecOnlyKindByDescription(desc)
+        const provider: any = {
+            version: providerVersion,
+            prefix: providerPrefix,
+            kinds: [kind],
+            procedures: {},
+            extension_structure: {},
+            allowExtraProps: false
+        };
+        providerApi.post('/', provider).then(() => done.fail()).catch(() => done());
+    });
+
+    test("Register provider with spec only kind structure", done => {
+        const desc = getSpecOnlyKindDescription()
+        const kind = getSpecOnlyKindByDescription(desc)
+        const provider: Provider = {
+            version: providerVersion,
+            prefix: providerPrefix,
+            kinds: [kind],
+            procedures: {},
+            extension_structure: {},
+            allowExtraProps: false
+        };
+        providerApi.post('/', provider).then(() => done()).catch(() => done.fail());
     });
 
     test("Register provider with malformed entity procedures", done => {

--- a/papiea-engine/__tests__/provider_tests/provider_api.test.ts
+++ b/papiea-engine/__tests__/provider_tests/provider_api.test.ts
@@ -68,37 +68,35 @@ describe("Provider API tests", () => {
         providerApi.post('/', provider).then(() => done.fail()).catch(() => done());
     });
 
-    test("Register provider with spec only kind structure with status only fields", done => {
+    test("Register provider with spec only kind structure with status only fields", async () => {
+        expect.assertions(1)
         const desc = getSpecOnlyKindDescriptionWithStatusOnlyFields()
         const kind = getSpecOnlyKindByDescription(desc)
-        const provider: any = {
-            version: providerVersion,
-            prefix: providerPrefix,
-            kinds: [kind],
-            procedures: {},
-            extension_structure: {},
-            allowExtraProps: false
-        };
-        providerApi.post('/', provider).then((e) => done.fail()).catch(() => done());
+                const provider: Provider = new ProviderBuilder().withVersion("0.1.0").withKinds([kind]).build();
+        try {
+            await providerApi.post('/', provider);
+        } catch (e) {
+            expect(e.response.data.error.errors[0].message).toBe("x-papiea has wrong value: status-only, the field should not be present");
+        }
     });
 
-    test("Register provider with spec only kind structure with spec only fields", done => {
+    test("Register provider with spec only kind structure with spec only fields", async () => {
+        expect.assertions(1)
         const desc = getSpecOnlyKindDescriptionWithSpecOnlyFields()
         const kind = getSpecOnlyKindByDescription(desc)
-        const provider: any = {
-            version: providerVersion,
-            prefix: providerPrefix,
-            kinds: [kind],
-            procedures: {},
-            extension_structure: {},
-            allowExtraProps: false
-        };
-        providerApi.post('/', provider).then(() => done.fail()).catch(() => done());
+        const provider: Provider = new ProviderBuilder().withVersion("0.1.0").withKinds([kind]).build();
+        try {
+            await providerApi.post('/', provider);
+        } catch (e) {
+            expect(e.response.data.error.errors[0].message).toBe("x-papiea has wrong value: spec-only, possible values are: status-only");
+        }
     });
 
-    test("Register provider with spec only kind structure", done => {
+    test("Register provider with spec only kind structure", async () => {
+        expect.assertions(1)
         const provider: Provider = new ProviderBuilder().withVersion("0.1.0").withKinds([getBasicKind()]).build();
-        providerApi.post('/', provider).then(() => done()).catch(() => done.fail());
+        const result = await providerApi.post('/', provider);
+        expect(result.status).toEqual(200)
     });
 
     test("Register provider with malformed entity procedures", done => {

--- a/papiea-engine/__tests__/provider_tests/provider_api.test.ts
+++ b/papiea-engine/__tests__/provider_tests/provider_api.test.ts
@@ -1,11 +1,11 @@
 import "jest"
 import axios from "axios"
 import {
+    getBasicKind,
     getClusterKind,
     getClusterKindWithNullableFields,
     getSpecOnlyArrayKind,
     getSpecOnlyKindByDescription,
-    getSpecOnlyKindDescription,
     getSpecOnlyKindDescriptionWithSpecOnlyFields,
     getSpecOnlyKindDescriptionWithStatusOnlyFields,
     loadYamlFromTestFactoryDir,
@@ -97,16 +97,7 @@ describe("Provider API tests", () => {
     });
 
     test("Register provider with spec only kind structure", done => {
-        const desc = getSpecOnlyKindDescription()
-        const kind = getSpecOnlyKindByDescription(desc)
-        const provider: Provider = {
-            version: providerVersion,
-            prefix: providerPrefix,
-            kinds: [kind],
-            procedures: {},
-            extension_structure: {},
-            allowExtraProps: false
-        };
+        const provider: Provider = new ProviderBuilder().withVersion("0.1.0").withKinds([getBasicKind()]).build();
         providerApi.post('/', provider).then(() => done()).catch(() => done.fail());
     });
 

--- a/papiea-engine/__tests__/test_data_factory.ts
+++ b/papiea-engine/__tests__/test_data_factory.ts
@@ -112,6 +112,22 @@ export function getBasicKind(): SpecOnlyEntityKind {
     }
 }
 
+export function getSpecOnlyKindDescriptionWithStatusOnlyFields(): Data_Description {
+        const description: any = getLocationDataDescription();
+    description[Object.keys(description)[0]].properties.y["x-papiea"] = "status-only"
+    return description
+}
+
+export function getSpecOnlyKindDescription(): Data_Description {
+    return getLocationDataDescription()
+}
+
+export function getSpecOnlyKindDescriptionWithSpecOnlyFields(): Data_Description {
+    const description: any = getLocationDataDescription();
+    description[Object.keys(description)[0]].properties.y["x-papiea"] = "spec-only"
+    return description
+}
+
 export function getSpecOnlyArrayKind(): SpecOnlyEntityKind {
     const locationDataDescription = getLocationArrayDataDescription();
     const name = Object.keys(locationDataDescription)[0];
@@ -126,6 +142,22 @@ export function getSpecOnlyArrayKind(): SpecOnlyEntityKind {
         differ: undefined,
         intentful_behaviour: IntentfulBehaviour.Basic
     };
+}
+
+export function getSpecOnlyKindByDescription(desc: Data_Description): SpecOnlyEntityKind {
+    const name = Object.keys(desc)[0];
+    const locationKind: SpecOnlyEntityKind = {
+        name,
+        name_plural: plural(name),
+        kind_structure: desc,
+        intentful_signatures: [],
+        dependency_tree: new Map(),
+        kind_procedures: {},
+        entity_procedures: {},
+        differ: undefined,
+        intentful_behaviour: IntentfulBehaviour.SpecOnly
+    };
+    return locationKind;
 }
 
 export function getDifferKind(): Kind {

--- a/papiea-engine/__tests__/test_data_factory.ts
+++ b/papiea-engine/__tests__/test_data_factory.ts
@@ -4,17 +4,18 @@ import { resolve } from "path";
 import { plural } from "pluralize";
 import {
     Data_Description,
-    Version,
+    IntentfulBehaviour,
     Kind,
+    Procedural_Execution_Strategy,
     Procedural_Signature,
     Provider,
-    Procedural_Execution_Strategy,
-    SpecOnlyEntityKind
+    SpecOnlyEntityKind,
+    Version
 } from "papiea-core";
 import * as http from "http";
+import { IncomingMessage, ServerResponse } from "http";
 import uuid = require("uuid");
-import { IncomingMessage, ServerResponse } from "http"
-import { IntentfulBehaviour } from "papiea-core"
+
 const url = require("url");
 const queryString = require("query-string");
 
@@ -37,6 +38,22 @@ export function getLocationDataDescription(): Data_Description {
     let randomizedLocationDataDescription: any = {};
     randomizedLocationDataDescription["Location" + randomString(5)] = locationDataDescription["Location"];
     return randomizedLocationDataDescription;
+}
+
+export function getSpecOnlyKindDescriptionWithStatusOnlyFields(): Data_Description {
+    return getLocationDataDescription()
+}
+
+export function getSpecOnlyKindDescription(): Data_Description {
+    const description: any = getLocationDataDescription();
+    delete description[Object.keys(description)[0]].properties.z["x-papiea"]
+    return description
+}
+
+export function getSpecOnlyKindDescriptionWithSpecOnlyFields(): Data_Description {
+    const description: any = getLocationDataDescription();
+    description[Object.keys(description)[0]].properties.z["x-papiea"] = "spec-only"
+    return description
 }
 
 export function getLocationArrayDataDescription(): Data_Description {
@@ -80,6 +97,22 @@ export function getSpecOnlyKind(): SpecOnlyEntityKind {
         name,
         name_plural: plural(name),
         kind_structure: locationDataDescription,
+        intentful_signatures: [],
+        dependency_tree: new Map(),
+        kind_procedures: {},
+        entity_procedures: {},
+        differ: undefined,
+        intentful_behaviour: IntentfulBehaviour.SpecOnly
+    };
+    return locationKind;
+}
+
+export function getSpecOnlyKindByDescription(desc: Data_Description): SpecOnlyEntityKind {
+    const name = Object.keys(desc)[0];
+    const locationKind: SpecOnlyEntityKind = {
+        name,
+        name_plural: plural(name),
+        kind_structure: desc,
         intentful_signatures: [],
         dependency_tree: new Map(),
         kind_procedures: {},

--- a/papiea-engine/__tests__/validation_tests/validation.test.ts
+++ b/papiea-engine/__tests__/validation_tests/validation.test.ts
@@ -214,30 +214,21 @@ describe("Validation tests", () => {
         }).toThrow()
     });
 
-    test("Validator validate spec only kind structure with spec-only value x-papiea field", async () => {
-        expect.assertions(1)
+    test("Validator validate incorrect spec only kind structure with x-papiea=spec-only", () => {
         const desc = getSpecOnlyKindDescriptionWithSpecOnlyFields()
         const kindStructure = desc[Object.keys(desc)[0]]
-        expect(() => {
-            validator.validateKindStructure(kindStructure)
-        }).toThrow()
+        expect(() => validator.validateKindStructure(kindStructure)).toThrow()
     })
 
-    test("Validator validate spec only kind structure with status-only value x-papiea field", async () => {
-        expect.assertions(1)
+    test("Validator validate incorrect spec only kind structure with x-papiea=status-only", () => {
         const desc = getSpecOnlyKindDescriptionWithStatusOnlyFields()
         const kindStructure = desc[Object.keys(desc)[0]]
-        expect(() => {
-            validator.validateKindStructure(kindStructure)
-        }).toThrow()
+        expect(()=>validator.validateKindStructure(kindStructure)).toThrow()
     })
 
-    test("Validator validate correct spec only kind structure", async () => {
-        expect.assertions(1)
+    test("Validator validate correct spec only kind structure", () => {
         const desc = getSpecOnlyKindDescription()
         const kindStructure = desc[Object.keys(desc)[0]]
-        expect(() => {
-            validator.validateKindStructure(kindStructure)
-        }).not.toThrow()
+        validator.validateKindStructure(kindStructure)
     })
 });

--- a/papiea-engine/__tests__/validation_tests/validation.test.ts
+++ b/papiea-engine/__tests__/validation_tests/validation.test.ts
@@ -4,6 +4,9 @@ import {
     getBasicEntityLocationDataDescription,
     getLocationDataDescription,
     getSpecOnlyKind,
+    getSpecOnlyKindDescription,
+    getSpecOnlyKindDescriptionWithSpecOnlyFields,
+    getSpecOnlyKindDescriptionWithStatusOnlyFields,
     ValidationBuilder
 } from "../test_data_factory"
 import uuid = require("uuid")

--- a/papiea-engine/__tests__/validation_tests/validation.test.ts
+++ b/papiea-engine/__tests__/validation_tests/validation.test.ts
@@ -1,6 +1,11 @@
 import "jest"
 import { ValidatorImpl } from "../../src/validator";
-import { getLocationDataDescription, getSpecOnlyKind, ValidationBuilder } from "../test_data_factory";
+import {
+    getLocationDataDescription,
+    getSpecOnlyKind, getSpecOnlyKindDescription,
+    getSpecOnlyKindDescriptionWithSpecOnlyFields, getSpecOnlyKindDescriptionWithStatusOnlyFields,
+    ValidationBuilder
+} from "../test_data_factory";
 import uuid = require("uuid")
 import { SpecOnlyEntityKind } from "papiea-core"
 
@@ -205,4 +210,31 @@ describe("Validation tests", () => {
             validator.validate_uuid(kind_with_pattern, id)
         }).toThrow()
     });
+
+    test("Validator validate spec only kind structure with spec-only value x-papiea field", async () => {
+        expect.assertions(1)
+        const desc = getSpecOnlyKindDescriptionWithSpecOnlyFields()
+        const kindStructure = desc[Object.keys(desc)[0]]
+        expect(() => {
+            validator.validateKindStructure(kindStructure)
+        }).toThrow()
+    })
+
+    test("Validator validate spec only kind structure with status-only value x-papiea field", async () => {
+        expect.assertions(1)
+        const desc = getSpecOnlyKindDescriptionWithStatusOnlyFields()
+        const kindStructure = desc[Object.keys(desc)[0]]
+        expect(() => {
+            validator.validateKindStructure(kindStructure)
+        }).toThrow()
+    })
+
+    test("Validator validate correct spec only kind structure", async () => {
+        expect.assertions(1)
+        const desc = getSpecOnlyKindDescription()
+        const kindStructure = desc[Object.keys(desc)[0]]
+        expect(() => {
+            validator.validateKindStructure(kindStructure)
+        }).not.toThrow()
+    })
 });

--- a/papiea-engine/__tests__/validation_tests/validation.test.ts
+++ b/papiea-engine/__tests__/validation_tests/validation.test.ts
@@ -217,18 +217,18 @@ describe("Validation tests", () => {
     test("Validator validate incorrect spec only kind structure with x-papiea=spec-only", () => {
         const desc = getSpecOnlyKindDescriptionWithSpecOnlyFields()
         const kindStructure = desc[Object.keys(desc)[0]]
-        expect(() => validator.validateKindStructure(kindStructure)).toThrow()
+        expect(() => validator.validate_kind_structure(kindStructure)).toThrow()
     })
 
     test("Validator validate incorrect spec only kind structure with x-papiea=status-only", () => {
         const desc = getSpecOnlyKindDescriptionWithStatusOnlyFields()
         const kindStructure = desc[Object.keys(desc)[0]]
-        expect(()=>validator.validateKindStructure(kindStructure)).toThrow()
+        expect(()=>validator.validate_kind_structure(kindStructure)).toThrow()
     })
 
     test("Validator validate correct spec only kind structure", () => {
         const desc = getSpecOnlyKindDescription()
         const kindStructure = desc[Object.keys(desc)[0]]
-        validator.validateKindStructure(kindStructure)
+        validator.validate_kind_structure(kindStructure)
     })
 });

--- a/papiea-engine/src/api_docs/api_docs_generator.ts
+++ b/papiea-engine/src/api_docs/api_docs_generator.ts
@@ -611,10 +611,10 @@ export default class ApiDocsGenerator {
         for (let prop in schema) {
             // check that it's a object holding properties
             if (typeof schema[prop] === 'object' && schema[prop].hasOwnProperty("required") && schema[prop].hasOwnProperty("properties")) {
-                const fieldsToRemove: string[] = [];
-                const properties = schema[prop]["properties"];
+                const fieldsToRemove: string[] = []
+                const properties = schema[prop]["properties"]
                 for (let name in properties) {
-                    const field = properties[name];
+                    const field = properties[name]
                     // if property has value of `fieldname` we should remove it from required
                     if (typeof field === 'object' && field.hasOwnProperty("x-papiea") && field["x-papiea"] === fieldName) {
                         fieldsToRemove.push(name)
@@ -629,7 +629,7 @@ export default class ApiDocsGenerator {
             }
             if (typeof schema[prop] === 'object') {
                 // check for child objects as they may be object structures with required fields
-                this.removeRequiredField(schema[prop], fieldName);
+                this.removeRequiredField(schema[prop], fieldName)
             }
         }
     }
@@ -642,9 +642,9 @@ export default class ApiDocsGenerator {
     removeSchemaField(schema: any, fieldName: string) {
         for (let prop in schema) {
             if (typeof schema[prop] === 'object' && "x-papiea" in schema[prop] && schema[prop]["x-papiea"] === fieldName) {
-                delete schema[prop];
+                delete schema[prop]
             } else if (typeof schema[prop] === 'object')
-                this.removeSchemaField(schema[prop], fieldName);
+                this.removeSchemaField(schema[prop], fieldName)
         }
     }
 

--- a/papiea-engine/src/api_docs/api_docs_generator.ts
+++ b/papiea-engine/src/api_docs/api_docs_generator.ts
@@ -648,18 +648,14 @@ export default class ApiDocsGenerator {
         }
     }
 
-    clearSchemaField(schema: any, fieldName: string) {
-        this.removeRequiredField(schema, fieldName)
-        this.removeSchemaField(schema, fieldName)
-    }
-
     createSchema(schemas: any, kind: Kind, type: string) {
         const kindSchema: any = JSON.parse(JSON.stringify(kind.kind_structure))
         const schemaName = Object.keys(kindSchema)[0]
         if (type === "spec") {
             kindSchema[ `${ schemaName }-Spec` ] = kindSchema[ schemaName ]
             delete kindSchema[ schemaName ]
-            this.clearSchemaField(kindSchema, "status-only")
+            this.removeRequiredField(kindSchema, "status-only")
+            this.removeSchemaField(kindSchema, "status-only")
         } else if (type === "metadata") {
             kindSchema[ `${ schemaName }-Metadata` ] = this.getMetadata(kind.uuid_validation_pattern)["Metadata"]
         } else {

--- a/papiea-engine/src/api_docs/api_docs_generator.ts
+++ b/papiea-engine/src/api_docs/api_docs_generator.ts
@@ -604,8 +604,8 @@ export default class ApiDocsGenerator {
 
     /**
      * Recursively removes a field from required if it has to be shown only for the opposite type.
-     * @param {number} schema - schema to remove the fields from.
-     * @param {number} fieldName - type of x-papiea value spec-only|status-only.
+     * @param schema - schema to remove the fields from.
+     * @param fieldName - type of x-papiea value spec-only|status-only.
      */
     removeRequiredField(schema: any, fieldName: string) {
         for (let prop in schema) {
@@ -636,8 +636,8 @@ export default class ApiDocsGenerator {
 
     /**
      * Recursively removes a field from properties if it has to be shown only for the opposite type.
-     * @param {number} schema - schema to remove the fields from.
-     * @param {number} fieldName - type of x-papiea value spec-only|status-only.
+     * @param schema - schema to remove the fields from.
+     * @param fieldName - type of x-papiea value spec-only|status-only.
      */
     removeSchemaField(schema: any, fieldName: string) {
         for (let prop in schema) {

--- a/papiea-engine/src/api_docs/api_docs_generator.ts
+++ b/papiea-engine/src/api_docs/api_docs_generator.ts
@@ -610,11 +610,11 @@ export default class ApiDocsGenerator {
     removeRequiredField(schema: any, fieldName: string) {
         for (let prop in schema) {
             // check that it's a object holding properties
-            if (typeof schema[prop] === 'object' && "required" in schema[prop] && "properties" in schema[prop]) {
-                const fieldsToRemove: String[] = []
-                const properties = schema[prop]["properties"]
+            if (typeof schema[prop] === 'object' && schema[prop].hasOwnProperty("required") && schema[prop].hasOwnProperty("properties")) {
+                const fieldsToRemove: string[] = [];
+                const properties = schema[prop]["properties"];
                 for (let name in properties) {
-                    const field = properties[name]
+                    const field = properties[name];
                     // if property has value of `fieldname` we should remove it from required
                     if (typeof field === 'object' && field.hasOwnProperty("x-papiea") && field["x-papiea"] === fieldName) {
                         fieldsToRemove.push(name)

--- a/papiea-engine/src/api_docs/api_docs_generator.ts
+++ b/papiea-engine/src/api_docs/api_docs_generator.ts
@@ -604,7 +604,7 @@ export default class ApiDocsGenerator {
 
     /**
      * Recursively removes a field from required if it has to be shown only for the opposite type.
-     * @param schema - schema to remove the fields from.
+     * @param schema - schema to remove the required from.
      * @param fieldName - type of x-papiea value spec-only|status-only.
      */
     removeRequiredField(schema: any, fieldName: string) {

--- a/papiea-engine/src/validator/index.ts
+++ b/papiea-engine/src/validator/index.ts
@@ -152,9 +152,9 @@ export class ValidatorImpl {
     validateKindStructure(schema: Data_Description) {
         const xPapieaField = "x-papiea"
         const statusOnlyValue = "status-only"
-        // xPapieaField pryoperty have only statusOnlyValue value
+        // xPapieaField property have only statusOnlyValue value
         this.validateFieldValue(schema, xPapieaField, [statusOnlyValue])
-        this.validateSpecOnlyStructures(schema)
+        this.validateSpecOnlyStructure(schema)
     }
 
     validateFieldValue(schema: Data_Description, fieldName: string, possibleValues: string[]) {
@@ -176,7 +176,7 @@ export class ValidatorImpl {
         }
     }
 
-    validateSpecOnlyStructures(entity: Data_Description) {
+    validateSpecOnlyStructure(entity: Data_Description) {
         const specOnlyValue = "spec-only"
         const xPapieaEntityField = "x-papiea-entity"
         const xPapieaField = "x-papiea"

--- a/papiea-engine/src/validator/index.ts
+++ b/papiea-engine/src/validator/index.ts
@@ -144,28 +144,28 @@ export class ValidatorImpl {
                     undefined, true)
             })
             Object.values(kind.kind_structure).forEach(structure => {
-                this.validateKindStructure(structure)
+                this.validate_kind_structure(structure)
             })
         })
     }
 
-    validateKindStructure(schema: Data_Description) {
-        const xPapieaField = "x-papiea"
-        const statusOnlyValue = "status-only"
-        // xPapieaField property have only statusOnlyValue value
-        this.validateFieldValue(schema, xPapieaField, [statusOnlyValue])
-        this.validateSpecOnlyStructure(schema)
+    validate_kind_structure(schema: Data_Description) {
+        const x_papiea_field = "x-papiea"
+        const status_only_value = "status-only"
+        // x_papiea_field property have only status_only_value value
+        this.validate_field_value(schema, x_papiea_field, [status_only_value])
+        this.validate_spec_only_structure(schema)
     }
 
-    validateFieldValue(schema: Data_Description, fieldName: string, possibleValues: string[]) {
+    validate_field_value(schema: Data_Description, field_name: string, possible_values: string[]) {
         for (let prop in schema) {
             if (typeof schema[prop] === "object") {
-                if (fieldName in schema[prop]) {
-                    const xPapieaValue = schema[prop][fieldName]
-                    if (!possibleValues.includes(xPapieaValue)) {
-                        let message = `${fieldName} has wrong value: ${xPapieaValue}, `
-                        if (possibleValues.length > 0) {
-                            message += `possible values are: ${possibleValues.toString()}`
+                if (field_name in schema[prop]) {
+                    const value = schema[prop][field_name]
+                    if (!possible_values.includes(value)) {
+                        let message = `${field_name} has wrong value: ${value}, `
+                        if (possible_values.length > 0) {
+                            message += `possible values are: ${possible_values.toString()}`
                         } else {
                             message += "the field should not be present"
                         }
@@ -175,20 +175,20 @@ export class ValidatorImpl {
                         }])
                     }
                 } else {
-                    this.validateFieldValue(schema[prop], fieldName, possibleValues)
+                    this.validate_field_value(schema[prop], field_name, possible_values)
                 }
 
             }
         }
     }
 
-    validateSpecOnlyStructure(entity: Data_Description) {
-        const specOnlyValue = "spec-only"
-        const xPapieaEntityField = "x-papiea-entity"
-        const xPapieaField = "x-papiea"
-        if (typeof entity === "object" && entity.hasOwnProperty(xPapieaEntityField) && entity[xPapieaEntityField] === specOnlyValue) {
-            // spec-only entity can't have xPapieaField values
-            this.validateFieldValue(entity.properties, xPapieaField, [])
+    validate_spec_only_structure(entity: Data_Description) {
+        const spec_only_value = "spec-only"
+        const x_papiea_entity_field = "x-papiea-entity"
+        const x_papiea_field = "x-papiea"
+        if (typeof entity === "object" && entity.hasOwnProperty(x_papiea_entity_field) && entity[x_papiea_entity_field] === spec_only_value) {
+            // spec-only entity can't have x_papiea_field values
+            this.validate_field_value(entity.properties, x_papiea_field, [])
         }
     }
 

--- a/papiea-engine/src/validator/index.ts
+++ b/papiea-engine/src/validator/index.ts
@@ -159,13 +159,19 @@ export class ValidatorImpl {
 
     validateFieldValue(schema: Data_Description, fieldName: string, possibleValues: string[]) {
         for (let prop in schema) {
-            if (typeof schema[prop] === 'object') {
+            if (typeof schema[prop] === "object") {
                 if (fieldName in schema[prop]) {
                     const xPapieaValue = schema[prop][fieldName]
                     if (!possibleValues.includes(xPapieaValue)) {
+                        let message = `${fieldName} has wrong value: ${xPapieaValue}, `
+                        if (possibleValues.length > 0) {
+                            message += `possible values are: ${possibleValues.toString()}`
+                        } else {
+                            message += "the field should not be present"
+                        }
                         throw new ValidationError([{
                             name: "Error",
-                            message: `${fieldName} has wrong value: ${xPapieaValue}, possible values are: ${possibleValues.toString()}`
+                            message: message
                         }])
                     }
                 } else {

--- a/papiea-sdk/typescript/__tests__/test_data/location_kind_test_data.yml
+++ b/papiea-sdk/typescript/__tests__/test_data/location_kind_test_data.yml
@@ -11,9 +11,6 @@ Location:
       type: number
     y:
       type: number
-    z:
-      type: number
-      x-papiea: status-only
     v:
       type: object
       properties:


### PR DESCRIPTION
resolves #468 
When a field is marked as 'status-only" it doesn't appear in required fields for spec anymore