### PR TITLE
introduce appending changes to CHANGELOG.md when PR is merged to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/upgrade-versions.sh
+++ b/upgrade-versions.sh
@@ -97,8 +97,8 @@ fi
 
 # append version with PR link to the CHANGELOG.md
 commit_message=$(git log -n 1 --format=%s)
-# match (#$number) in the commit message
-pr_number=$(echo $commit_message | grep -oP "\(\#\K\d+")
+# match #$number in the commit message
+pr_number=$(echo $commit_message | grep -E "#[1-9]+\b")
 
 changelog_message="- Version $typescript_version: $commit_message"
 # if there is a PR number in the commit
@@ -123,6 +123,8 @@ fi
 git ls-files . | grep 'package\.json' | xargs git add
 
 git add README.md
+
+git add CHANGELOG.md
 
 git commit -m "[skip ci] Upgrade versions. Engine: $circle_num. Typescript: $typescipt_version. Python: $python_version."
 

--- a/upgrade-versions.sh
+++ b/upgrade-versions.sh
@@ -95,6 +95,18 @@ else
   " README.md
 fi
 
+# append version with PR link to the CHANGELOG.md
+commit_message=$(git log -n 1 --format=%s)
+# match (#$number) in the commit message
+pr_number=$(echo $commit_message | grep -oP "\(\#\K\d+")
+
+changelog_message="- Version $typescript_version: $commit_message"
+# if there is a PR number in the commit
+if [[ "$pr_number" -ne "" ]]; then
+  changelog_message+=" PR url: $CIRCLE_REPOSITORY_URL/pull/$pr_number"
+fi
+echo $changelog_message >> CHANGELOG.md
+
 echo "Python commit hash: $python_version ; Typescript version: $typescipt_version; Circle build number: $circle_num."
 
 if [[ "$accept" != true ]]; then

--- a/upgrade-versions.sh
+++ b/upgrade-versions.sh
@@ -105,7 +105,7 @@ changelog_message="- Version $typescript_version: $commit_message"
 if [[ "$pr_number" -ne "" ]]; then
   changelog_message+=" PR url: $CIRCLE_REPOSITORY_URL/pull/$pr_number"
 fi
-echo $changelog_message >> CHANGELOG.md
+sed -i "1i $changelog_message" CHANGELOG.md
 
 echo "Python commit hash: $python_version ; Typescript version: $typescipt_version; Circle build number: $circle_num."
 


### PR DESCRIPTION
issue #485 

appends message from the last commit when things are merged to master. (Assumed that the PR is squashed to 1 commit)

example of the addition to the CHANGELOG.md:
- Version 1.1: Upgrade version scripts and README version section (#479) PR url: https://github.com/nutanix/papiea/pull/479
