### PR TITLE
Add additional info in procedure invocation error

### DIFF
--- a/papiea-engine/src/errors/procedure_invocation_error.ts
+++ b/papiea-engine/src/errors/procedure_invocation_error.ts
@@ -25,9 +25,13 @@ export class ProcedureInvocationError extends Error {
                 stacktrace: err.response?.data.stacktrace
             }], err.response?.status ?? 500)
         } else if (err instanceof ValidationError) {
-            return new ProcedureInvocationError(err.errors.map(e => {
-                return { message: e }
-            }), status || 500)
+            return new ProcedureInvocationError(
+                err.errors.map(e => ({
+                    message: e,
+                    errors: {},
+                    stacktrace: err.stack
+                }))
+            , status || 500)
         } else {
             return new ProcedureInvocationError([{
                 message: "Unknown error during procedure invocation",

--- a/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
+++ b/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
@@ -743,6 +743,8 @@ describe("Provider Sdk tests", () => {
             const res: any = await axios.post(`${sdk.entity_url}/${sdk.provider.prefix}/${sdk.provider.version}/procedure/computeSum`, { input: { "a": 5, "b": 5 } });
         } catch (e) {
             expect(e.response.data.error.errors[0].message).toBe("Unable to validate a model with a type: string, expected: number");
+            expect(e.response.data.error.errors[0].stacktrace).not.toBeUndefined();
+            expect(e.response.data.error.errors[0].stacktrace).toContain("Unable to validate a model with a type: string, expected: number")
             expect(e.response.data.error.code).toBe(500);
         } finally {
             sdk.server.close();


### PR DESCRIPTION
Added stacktrace and errors field for validation error in procedure invocation and test to verify the same.

So far, I've added additional information for the `validation error` within the `Procedure Invocation Error` and will look at other places as well to ensure proper value for fields in error type.