### PR TITLE
Added module to remove status-only fields from entity status

### DIFF
--- a/papiea-client/__tests__/filter.test.ts
+++ b/papiea-client/__tests__/filter.test.ts
@@ -1,7 +1,7 @@
 import { kind_client } from "../src/entity_client"
 import { ProviderBuilder } from "../../papiea-engine/__tests__/test_data_factory"
 import axios from "axios"
-import { EntitySpec } from "papiea-core"
+import { Spec } from "papiea-core"
 
 declare var process: {
     env: {
@@ -42,7 +42,7 @@ describe("Entity API tests", () => {
         for (let i of specs) {
             promises.push(location_client.create({x: i, y: i}))
         }
-        const res = await Promise.all<EntitySpec>(promises)
+        const res = await Promise.all<Spec>(promises)
         res.map(entity => uuids.push(entity.metadata.uuid))
         let entity_count = 0
         const iterator = await location_client.filter_iter({})
@@ -67,7 +67,7 @@ describe("Entity API tests", () => {
         for (let i of specs) {
             promises.push(location_client.create({x: i, y: i}))
         }
-        const res = await Promise.all<EntitySpec>(promises)
+        const res = await Promise.all<Spec>(promises)
         res.map(entity => uuids.push(entity.metadata.uuid))
         let entity_count = 0
         const iterator = await location_client.filter_iter({})
@@ -91,7 +91,7 @@ describe("Entity API tests", () => {
         for (let i of specs) {
             promises.push(location_client.create({x: i, y: i}))
         }
-        const res = await Promise.all<EntitySpec>(promises)
+        const res = await Promise.all<Spec>(promises)
         res.map(entity => uuids.push(entity.metadata.uuid))
         let entity_count = 0
         const iterator = await location_client.list_iter()

--- a/papiea-client/__tests__/update.test.ts
+++ b/papiea-client/__tests__/update.test.ts
@@ -44,7 +44,7 @@ describe("Entity API tests", () => {
         const location_client = kind_client("http://localhost:3000", providerPrefix, kind_name, providerVersion, '')
         const entity = await location_client.create({x: 10, y: 10})
         const watcher = await location_client.update(entity.metadata, {x: 12, y: 10})
-        expect(watcher!.status).toEqual(IntentfulStatus.Pending)
+        expect(watcher!.status).toEqual(IntentfulStatus.Active)
         await location_client.delete(entity.metadata)
     })
 })

--- a/papiea-core/src/core.ts
+++ b/papiea-core/src/core.ts
@@ -149,6 +149,9 @@ export interface Differ {
     // original dependency tree
     all_diffs(kind: Kind, spec: Spec, status: Status): Diff[];
 
+    // Removes status-only fields from the entity status using the schema
+    remove_status_only_fields(schema: any, status: Status): Status;
+
     // Get current value by path specified in diff fields
     get_diff_path_value(diff: DiffContent, spec: Spec): any
 }

--- a/papiea-engine/src/intentful_engine/diff_resolver.ts
+++ b/papiea-engine/src/intentful_engine/diff_resolver.ts
@@ -99,49 +99,22 @@ export class DiffResolver {
     private async rediff(entry_reference: EntryReference): Promise<RediffResult | null> {
         try {
             const [metadata, spec] = await this.specDb.get_spec(entry_reference.entity_reference)
-            let [, status] = await this.statusDb.get_status({...entry_reference.provider_reference, ...entry_reference.entity_reference})
+            const [, status] = await this.statusDb.get_status({...entry_reference.provider_reference, ...entry_reference.entity_reference})
             const provider = await this.providerDb.get_provider(entry_reference.provider_reference.provider_prefix, entry_reference.provider_reference.provider_version)
             const kind = this.providerDb.find_kind(provider, metadata.kind)
-            const schemas: any = Object.assign({}, kind.kind_structure);
-            status = this.remove_status_only_fields(schemas[kind.name], status);
+            let diff_status: any = {}
+            if (status !== undefined) {
+                diff_status = JSON.parse(JSON.stringify(status));
+            }
+            diff_status = this.differ.remove_status_only_fields(kind.kind_structure[kind.name], diff_status);
             return {
-                diffs: this.differ.all_diffs(kind, spec, status),
+                diffs: this.differ.all_diffs(kind, spec, diff_status),
                 metadata, provider, kind, spec, status,
             };
         } catch (e) {
             this.logger.debug(`Couldn't rediff entity with uuid ${entry_reference.entity_reference.uuid}: ${e}. Removing from watchlist`)
             return null
         }
-    }
-
-    private remove_status_only_fields(schema: any, status: Status): Status {
-        if (schema) {
-            // Return null for fields that are status-only
-            if (schema.hasOwnProperty('x-papiea') && schema['x-papiea'] === 'status-only') {
-                return null
-            }
-            if (schema.type === 'object' && status && Object.keys(status).length !== 0) {
-                const properties = schema['properties']
-                for (let name in properties) {
-                    status[name] = this.remove_status_only_fields(properties[name], status[name])
-                    // If received null i.e. a status-only field, delete the field from status object
-                    if (status[name] === null) {
-                        delete status[name]
-                    }
-                }
-            } else if (schema.type === 'array' && status && status.length !== 0) {
-                let i = 0;
-                // Loop through all values in array and inspect status-only for each
-                for (let item of status) {
-                    status[i] = this.remove_status_only_fields(schema['items'], item)
-                    i++
-                }
-                // If the array element has all status-only fields, it would be set to empty object
-                // based on the above logic, so remove the element from array to avoid empty values.
-                status = status.filter((item: any) => Object.keys(item).length !== 0);
-            }
-        }
-        return status
     }
 
     private async launchOperation({diff, metadata, spec, status}: DiffWithContext): Promise<Delay | null> {

--- a/papiea-engine/src/intentful_engine/diff_resolver.ts
+++ b/papiea-engine/src/intentful_engine/diff_resolver.ts
@@ -99,9 +99,11 @@ export class DiffResolver {
     private async rediff(entry_reference: EntryReference): Promise<RediffResult | null> {
         try {
             const [metadata, spec] = await this.specDb.get_spec(entry_reference.entity_reference)
-            const [, status] = await this.statusDb.get_status({...entry_reference.provider_reference, ...entry_reference.entity_reference})
+            let [, status] = await this.statusDb.get_status({...entry_reference.provider_reference, ...entry_reference.entity_reference})
             const provider = await this.providerDb.get_provider(entry_reference.provider_reference.provider_prefix, entry_reference.provider_reference.provider_version)
             const kind = this.providerDb.find_kind(provider, metadata.kind)
+            const schemas: any = Object.assign({}, kind.kind_structure);
+            status = this.remove_status_only_fields(schemas[kind.name], status);
             return {
                 diffs: this.differ.all_diffs(kind, spec, status),
                 metadata, provider, kind, spec, status,
@@ -110,6 +112,36 @@ export class DiffResolver {
             this.logger.debug(`Couldn't rediff entity with uuid ${entry_reference.entity_reference.uuid}: ${e}. Removing from watchlist`)
             return null
         }
+    }
+
+    private remove_status_only_fields(schema: any, status: Status): Status {
+        if (schema) {
+            // Return null for fields that are status-only
+            if (schema.hasOwnProperty('x-papiea') && schema['x-papiea'] === 'status-only') {
+                return null
+            }
+            if (schema.type === 'object' && status && Object.keys(status).length !== 0) {
+                const properties = schema['properties']
+                for (let name in properties) {
+                    status[name] = this.remove_status_only_fields(properties[name], status[name])
+                    // If received null i.e. a status-only field, delete the field from status object
+                    if (status[name] === null) {
+                        delete status[name]
+                    }
+                }
+            } else if (schema.type === 'array' && status && status.length !== 0) {
+                let i = 0;
+                // Loop through all values in array and inspect status-only for each
+                for (let item of status) {
+                    status[i] = this.remove_status_only_fields(schema['items'], item)
+                    i++
+                }
+                // If the array element has all status-only fields, it would be set to empty object
+                // based on the above logic, so remove the element from array to avoid empty values.
+                status = status.filter((item: any) => Object.keys(item).length !== 0);
+            }
+        }
+        return status
     }
 
     private async launchOperation({diff, metadata, spec, status}: DiffWithContext): Promise<Delay | null> {

--- a/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
+++ b/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
@@ -1078,6 +1078,9 @@ describe("Provider Sdk tests", () => {
                             a: {
                                 'x-papiea': 'status-only',
                                 type: 'string'
+                            },
+                            b: {
+                                type: 'string'
                             }
                         }
                     }
@@ -1096,7 +1099,8 @@ describe("Provider Sdk tests", () => {
                 await ctx.update_status(entity.metadata, {
                     test: [{
                         id: 'test-idval',
-                        a: 'test-aval'
+                        a: 'test-aval',
+                        b: 'test-aval'
                     }]
                 })
             })
@@ -1110,7 +1114,8 @@ describe("Provider Sdk tests", () => {
                 spec: {
                     test: [
                         {
-                            id: 'test-idval'
+                            id: 'test-idval',
+                            b: 'test-aval'
                         }
                     ]
                 }

--- a/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
+++ b/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
@@ -3,6 +3,7 @@ import { load } from "js-yaml";
 import { resolve } from "path";
 import { plural } from "pluralize"
 import { loadYamlFromTestFactoryDir, OAuth2Server, ProviderBuilder } from "../../../../papiea-engine/__tests__/test_data_factory";
+import { timeout } from "../../../../papiea-engine/src/utils/utils"
 import axios from "axios"
 import { readFileSync } from "fs";
 import { Metadata, IntentfulBehaviour, Provider, Spec, Action, Entity_Reference, Entity } from "papiea-core";
@@ -1058,6 +1059,76 @@ describe("Provider Sdk tests", () => {
             sdk.server.close();
         }
     });
+
+    const STATUS_ONLY_TEST_SCHEMA = {
+        TestObject: {
+            type: 'object',
+            title: 'testobject',
+            'x-papiea-entity': 'differ',
+            required: ['test'],
+            properties: {
+                test: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            id: {
+                                type: 'string'
+                            },
+                            a: {
+                                'x-papiea': 'status-only',
+                                type: 'string'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    test("Diff resolver should not run if only diff field is a status-only field", async () => {
+        expect.assertions(3)
+        const sdk = ProviderSdk.create_provider(papieaUrl, adminKey, server_config.host, server_config.port);
+        try {
+            const nested_object = sdk.new_kind(STATUS_ONLY_TEST_SCHEMA);
+            sdk.version(provider_version);
+            sdk.prefix("test_provider");
+            nested_object.on('test.+{id}', async(ctx, entity, diff) => {
+                await ctx.update_status(entity.metadata, {
+                    test: [{
+                        id: 'test-idval',
+                        a: 'test-aval'
+                    }]
+                })
+            })
+            nested_object.on('test.{id}', async (ctx, entity, diff) => {
+                throw new Error("Update intent handler should not be called")
+            });
+
+            await sdk.register();
+            const kind_name = sdk.provider.kinds[0].name;
+            const { data: { metadata, spec } } = await axios.post(`${sdk.entity_url}/${sdk.provider.prefix}/${sdk.provider.version}/${kind_name}`, {
+                spec: {
+                    test: [
+                        {
+                            id: 'test-idval'
+                        }
+                    ]
+                }
+            });
+
+            await timeout(5000)
+
+            const updatedEntity: any = await axios.get(`${sdk.entity_url}/${sdk.provider.prefix}/${sdk.provider.version}/${kind_name}/${metadata.uuid}`);
+            expect(updatedEntity.data.spec.test[0].id).toEqual('test-idval')
+            expect(updatedEntity.data.status.test[0].id).toEqual('test-idval')
+            expect(updatedEntity.data.status.test[0].a).toEqual('test-aval')
+        } catch (e) {
+            expect(e.response.data).toBeDefined()
+            expect(e.response.data.error.message).toBe("Update intent handler should not be called")
+        } finally {
+            sdk.server.close();
+        }
+    })
 });
 
 describe("SDK + oauth provider tests", () => {

--- a/papiea-sdk/typescript/src/provider_sdk/typescript_sdk_exceptions.ts
+++ b/papiea-sdk/typescript/src/provider_sdk/typescript_sdk_exceptions.ts
@@ -26,7 +26,7 @@ export class InvocationError extends Error {
             return new InvocationError(e.status || 500, e.message, e.errors, e.stack)
         }
         if (isAxiosError(e)) {
-            return new InvocationError(e.response!.status, "Error while making request", e.response!.data.errors)
+            return new InvocationError(e.response!.status, "Error while making request", e.response!.data?.errors)
         }
         return new InvocationError(status_code, e.message, [], e.stack)
     }
@@ -58,7 +58,7 @@ export class SecurityApiError extends Error {
     static fromError(e: Error, message: string): SecurityApiError {
         if (isAxiosError(e)) {
             if (e.response!.data.error) {
-                return new SecurityApiError(e.response!.data.error.errors, message, e.response!.status)
+                return new SecurityApiError(e.response!.data?.error?.errors, message, e.response!.status)
             } else {
                 return new SecurityApiError([e.response!.data], message, e.response!.status)
             }


### PR DESCRIPTION
Added module to loop through the entity schema and remove all the `status-only` fields from the entity status object.
Added test to verify the functionality