### PR TITLE
Added deprecate info for the replace_status sdk method and relavant tests

### DIFF
--- a/papiea-backend-utils/src/logging.ts
+++ b/papiea-backend-utils/src/logging.ts
@@ -9,7 +9,7 @@ export const LOG_LEVELS = {
     crit: 2,
     error: 3,
     audit: 4,
-    warning: 5,
+    warn: 5,
     notice: 6,
     info: 7,
     debug: 8,
@@ -30,7 +30,7 @@ export interface Logger {
     crit(msg: any, ...messages: any[]): void
     error(msg: any, ...messages: any[]): void
     audit(msg: any, ...messages: any[]): void
-    warning(msg: any, ...messages: any[]): void
+    warn(msg: any, ...messages: any[]): void
     notice(msg: any, ...messages: any[]): void
     info(msg: any, ...messages: any[]): void
     debug(msg: any, ...messages: any[]): void
@@ -191,8 +191,8 @@ class LoggerImpl implements Logger {
     audit(msg: any, ...messages: any[]): void {
         this._logger.log('audit', msg, ...messages)
     }
-    warning(msg: any, ...messages: any[]): void {
-        this._logger.warning(msg, ...messages)
+    warn(msg: any, ...messages: any[]): void {
+        this._logger.warn(msg, ...messages)
     }
     notice(msg: any, ...messages: any[]): void {
         this._logger.notice(msg, ...messages)

--- a/papiea-engine/src/databases/status_db_mongo.ts
+++ b/papiea-engine/src/databases/status_db_mongo.ts
@@ -59,7 +59,9 @@ export class Status_DB_Mongo implements Status_DB {
                     "metadata.provider_version": entity_ref.provider_version,
                     "metadata.uuid": entity_ref.uuid,
                     "metadata.kind": entity_ref.kind
-                }, aggregrate_fields);
+                }, aggregrate_fields, {
+                    upsert: true
+                });
         } catch (e) {
             if (e.code === 9) {
                 throw new Error(`Error parsing update query. Update body might be 'undefined', if this is expected, please use 'null'.`)

--- a/papiea-sdk/python/e2e_tests/procedure_handlers.py
+++ b/papiea-sdk/python/e2e_tests/procedure_handlers.py
@@ -277,6 +277,7 @@ async def bucket_create_handler(ctx, entity_bucket):
             name=entity_bucket.name,
             objects=list()
         )
+
         return ConstructorResult(spec=status, status=status, metadata={
             "extension": {
                 "owner": entity_bucket.owner

--- a/papiea-sdk/python/e2e_tests/requirements.txt
+++ b/papiea-sdk/python/e2e_tests/requirements.txt
@@ -5,6 +5,7 @@ attrs==19.3.0
 certifi==2020.6.20
 chardet==3.0.4
 cryptography==2.3
+Deprecated==1.2.10
 idna==2.10
 inflect==4.1.0
 keyring==10.6.0

--- a/papiea-sdk/python/papiea/python_sdk_context.py
+++ b/papiea-sdk/python/papiea/python_sdk_context.py
@@ -1,6 +1,6 @@
 import json
 from typing import List, Optional, Tuple
-
+from deprecated import deprecated
 from aiohttp import ClientSession
 from multidict import CIMultiDict
 
@@ -90,9 +90,18 @@ class ProceduralCtx(object):
             {"entity_ref": entity_reference, "status": status},
         )
 
+    @deprecated(version='0.11.0', reason="This function will be removed soon. Use update_status instead.")
     async def replace_status(
         self, entity_reference: EntityReference, status: Status
     ):
+        '''
+        Function which calls post on the update_status endpoint
+        which internally calls the mongo update function with upsert
+        flag set to true.
+
+        This functions inserts a new document if no matching document
+        is found for the query.
+        '''
         url = f"{self.provider.get_prefix()}/{self.provider.get_version()}"
         await self.provider_api.post(
             f"{url}/update_status",

--- a/papiea-sdk/typescript/src/provider_sdk/typescript_sdk_context_impl.ts
+++ b/papiea-sdk/typescript/src/provider_sdk/typescript_sdk_context_impl.ts
@@ -72,19 +72,30 @@ export class ProceduralCtx implements ProceduralCtx_Interface {
             status: status
         });
         if (res.status != 200) {
-            console.error("Could not update status:", entity_reference, status, res.status, res.data);
+            this.get_logger().error("Could not update status:", entity_reference, status, res.status, res.data);
             return false
         }
         return true
     }
 
+    /**
+     * Function which calls post on the update_status endpoint
+     * which internally calls the mongo update function with upsert
+     * flag set to true.
+     *
+     * This functions inserts a new document if no matching document
+     * is found for the query.
+     *
+     * @deprecated Will be deleted in version 0.11.0. Use update_status instead.
+    */
     async replace_status(entity_reference: Entity_Reference, status: Status, provider_prefix: string = this.provider.get_prefix(), provider_version: Version = this.provider.get_version()): Promise<boolean> {
+        this.get_logger().warn("Calling a deprecated method!!!")
         const res = await this.providerApiAxios.post(`${this.provider_url}/${provider_prefix}/${provider_version}/update_status`,{
             entity_ref: entity_reference,
             status: status
         });
         if (res.status != 200) {
-            console.error("Could not update status:", entity_reference, status, res.status, res.data);
+            this.get_logger().error("Could not update status:", entity_reference, status, res.status, res.data);
             return false
         }
         return true


### PR DESCRIPTION
- Added info about the function and deprecate tag for the replace_status sdk method.
- Added tests to verify the update_status method and ensure similarity to replace_status.
- Modified mongo update_status method to use upsert flag for update call.