### PR TITLE
Added semantic version check for the papiea sdk requests

### DIFF
--- a/papiea-client/__tests__/filter.test.ts
+++ b/papiea-client/__tests__/filter.test.ts
@@ -40,7 +40,7 @@ describe("Entity API tests", () => {
         let promises = []
         const specs = [1,2,3,4]
         for (let i of specs) {
-            promises.push(location_client.create({x: i, y: i}))
+            promises.push(location_client.create({spec: {x: i, y: i}}))
         }
         const res = await Promise.all<Spec>(promises)
         res.map(entity => uuids.push(entity.metadata.uuid))
@@ -65,7 +65,7 @@ describe("Entity API tests", () => {
         let promises = []
         const specs = [1,2,3,4]
         for (let i of specs) {
-            promises.push(location_client.create({x: i, y: i}))
+            promises.push(location_client.create({spec: {x: i, y: i}}))
         }
         const res = await Promise.all<Spec>(promises)
         res.map(entity => uuids.push(entity.metadata.uuid))
@@ -89,7 +89,7 @@ describe("Entity API tests", () => {
         let promises = []
         const specs = [1,2,3,4]
         for (let i of specs) {
-            promises.push(location_client.create({x: i, y: i}))
+            promises.push(location_client.create({spec: {x: i, y: i}}))
         }
         const res = await Promise.all<Spec>(promises)
         res.map(entity => uuids.push(entity.metadata.uuid))

--- a/papiea-client/__tests__/update.test.ts
+++ b/papiea-client/__tests__/update.test.ts
@@ -42,7 +42,7 @@ describe("Entity API tests", () => {
     test("Update should return entity watcher", async () => {
         expect.assertions(1)
         const location_client = kind_client("http://localhost:3000", providerPrefix, kind_name, providerVersion, '')
-        const entity = await location_client.create({x: 10, y: 10})
+        const entity = await location_client.create({spec: {x: 10, y: 10}})
         const watcher = await location_client.update(entity.metadata, {x: 12, y: 10})
         expect(watcher!.status).toEqual(IntentfulStatus.Active)
         await location_client.delete(entity.metadata)

--- a/papiea-client/src/entity_client.ts
+++ b/papiea-client/src/entity_client.ts
@@ -31,6 +31,9 @@ type EntitySpec = Pick<Entity, Metadata | Spec>
 
 const BATCH_SIZE = 20
 
+const packageJSON = require('../package.json');
+const PAPIEA_VERSION: string = packageJSON.version.split('+')[0];
+
 function delay(ms: number) {
     return new Promise( resolve => setTimeout(resolve, ms) );
 }
@@ -63,7 +66,7 @@ function make_request<T = any, Y = AxiosPromise<T>>(f: (url: string, data?: any,
 }
 
 async function create_entity(provider: string, kind: string, version: string, payload: any, papiea_url: string, s2skey: string): Promise<EntityCreationResult> {
-    const { data: { metadata, spec, intent_watcher, status } } = await make_request<EntityCreationResult>(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }`, payload, { headers: { "Authorization": `Bearer ${ s2skey }` } });
+    const { data: { metadata, spec, intent_watcher, status } } = await make_request<EntityCreationResult>(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }`, payload, { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
     return { metadata, spec, intent_watcher, status };
 }
 
@@ -73,32 +76,32 @@ async function update_entity(provider: string, kind: string, version: string, re
         metadata: {
             spec_version: request_metadata.spec_version
         }
-    }, { headers: { "Authorization": `Bearer ${ s2skey }` } });
+    }, { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
     return watcher
 }
 
 async function get_entity(provider: string, kind: string, version: string, entity_reference: Entity_Reference, papiea_url: string, s2skey: string): Promise<Entity> {
     const { data: { metadata, spec, status } } = await make_request(axios.get, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/${ entity_reference.uuid }`,
-        { headers: { "Authorization": `Bearer ${ s2skey }` } });
+        { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
     return { metadata, spec, status }
 }
 
 async function delete_entity(provider: string, kind: string, version: string, entity_reference: Entity_Reference, papiea_url: string, s2skey: string): Promise<void> {
-    await make_request(axios.delete, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/${ entity_reference.uuid }`, { headers: { "Authorization": `Bearer ${ s2skey }` } });
+    await make_request(axios.delete, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/${ entity_reference.uuid }`, { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
 }
 
 async function invoke_entity_procedure(provider: string, kind: string, version: string, procedure_name: string, input: any, entity_reference: Entity_Reference, papiea_url: string, s2skey: string): Promise<any> {
-    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/${ entity_reference.uuid }/procedure/${ procedure_name }`, { input }, { headers: { "Authorization": `Bearer ${ s2skey }` } });
+    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/${ entity_reference.uuid }/procedure/${ procedure_name }`, { input }, { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
     return res.data;
 }
 
 async function invoke_kind_procedure(provider: string, kind: string, version: string, procedure_name: string, input: any, papiea_url: string, s2skey: string): Promise<any> {
-    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/procedure/${ procedure_name }`, { input }, { headers: { "Authorization": `Bearer ${ s2skey }` } });
+    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/procedure/${ procedure_name }`, { input }, { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
     return res.data;
 }
 
 export async function invoke_provider_procedure(provider: string, version: string, procedure_name: string, input: any, papiea_url: string, s2skey: string): Promise<any> {
-    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/procedure/${ procedure_name }`, { input }, { headers: { "Authorization": `Bearer ${ s2skey }` } });
+    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/procedure/${ procedure_name }`, { input }, { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
     return res.data;
 }
 
@@ -108,12 +111,12 @@ export interface FilterResults {
 }
 
 export async function filter_entity_iter(provider: string, kind: string, version: string, filter: any, papiea_url: string, s2skey: string): Promise<(batch_size?: number, offset?: number) => AsyncGenerator<any, undefined, any>> {
-    const iter_func = await make_request(iter_filter, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/filter`, filter, { headers: { "Authorization": `Bearer ${ s2skey }` } });
+    const iter_func = await make_request(iter_filter, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/filter`, filter, { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
     return iter_func
 }
 
 export async function filter_entity(provider: string, kind: string, version: string, filter: any, papiea_url: string, s2skey: string): Promise<FilterResults> {
-    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/filter`, filter, { headers: { "Authorization": `Bearer ${ s2skey }` } });
+    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/filter`, filter, { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
     return res.data
 }
 
@@ -135,13 +138,13 @@ export async function iter_filter(url: string, data: any, config?: AxiosRequestC
 
 async function get_intent_watcher(papiea_url: string, id: string, s2skey: string): Promise<IntentWatcher> {
     const res = await make_request(axios.get, `${ papiea_url }/services/intent_watcher/${ id }`,
-        { headers: { "Authorization": `Bearer ${ s2skey }` } });
+        { headers: { "Authorization": `Bearer ${ s2skey }` }, "Papiea-Version": `${ PAPIEA_VERSION }` });
     return res.data
 }
 
 // filter_intent_watcher({'status':'Pending'})
 async function filter_intent_watcher(papiea_url: string, filter: any, s2skey: string): Promise<FilterResults> {
-    const res = await make_request(axios.post, `${ papiea_url }/services/intent_watcher/filter`, filter, { headers: { "Authorization": `Bearer ${ s2skey }` } });
+    const res = await make_request(axios.post, `${ papiea_url }/services/intent_watcher/filter`, filter, { headers: { "Authorization": `Bearer ${ s2skey }`, "Papiea-Version": `${ PAPIEA_VERSION }` } });
     return res.data
 }
 

--- a/papiea-engine/src/main.ts
+++ b/papiea-engine/src/main.ts
@@ -17,13 +17,16 @@ import { S2SKeyUserAuthInfoExtractor } from "./auth/s2s";
 import { Authorizer, AdminAuthorizer, PerProviderAuthorizer } from "./auth/authz";
 import { ValidatorImpl } from "./validator";
 import { ProviderCasbinAuthorizerFactory } from "./auth/casbin";
+import { BadRequestError } from "./errors/bad_request_error"
 import { PapieaErrorResponseImpl } from "./errors/papiea_error_impl";
 import { SessionKeyAPI, SessionKeyUserAuthInfoExtractor } from "./auth/session_key"
 import { IntentfulContext } from "./intentful_core/intentful_context"
 import { AuditLogger } from "./audit_logging"
 import { BasicDiffer } from "./intentful_core/differ_impl"
 import { getConfig } from "./utils/arg_parser"
+import { getPapieaVersion } from "./utils/utils"
 const cookieParser = require('cookie-parser');
+const semver = require('semver')
 
 process.title = "papiea"
 const config = getConfig()
@@ -65,6 +68,20 @@ async function setUpApplication(): Promise<express.Express> {
         new S2SKeyUserAuthInfoExtractor(s2skeyDb),
         new SessionKeyUserAuthInfoExtractor(sessionKeyApi, providerDb)
     ]);
+    const enginePapieaVersion = getPapieaVersion()
+    app.use(function (req: any, res: any, next: any) {
+        const headersPapieaVersion = req.headers['papiea-version']
+        if (headersPapieaVersion) {
+            if (semver.valid(headersPapieaVersion) === null) {
+                throw new BadRequestError(`Received invalid papiea version: ${headersPapieaVersion}`)
+            }
+            if (semver.diff(headersPapieaVersion, enginePapieaVersion) === 'major') {
+                throw new BadRequestError(`Received incompatible papiea version: ${headersPapieaVersion}`)
+            }
+        }
+
+        next();
+      })
     app.use(createAuthnRouter(logger, userAuthInfoExtractor));
     app.use(createOAuth2Router(logger, oauth2RedirectUri, providerDb, sessionKeyApi));
     app.use('/provider', createProviderAPIRouter(providerApi));

--- a/papiea-engine/src/utils/utils.ts
+++ b/papiea-engine/src/utils/utils.ts
@@ -146,3 +146,9 @@ export function getEntropyFn(papieaDebug: boolean) {
         return getRandomInt(min, max)
     }
 }
+
+export function getPapieaVersion(): string {
+    const packageJSON = require('../../package.json');
+    const engineSDKVersion: string = packageJSON.version.split('+')[0];
+    return engineSDKVersion
+}

--- a/papiea-engine/src/validator/express_validator.ts
+++ b/papiea-engine/src/validator/express_validator.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from "express";
+import { NextFunction, Request, Response, Router } from "express";
 import { BadRequestError } from "../errors/bad_request_error";
 
 interface RequestValidatorOptions {

--- a/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
+++ b/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
@@ -1266,6 +1266,107 @@ describe("Provider Sdk tests", () => {
             sdk.server.close();
         }
     });
+
+    test("Papiea version equal to the supported version should pass", async () => {
+        expect.hasAssertions();
+        const sdk = ProviderSdk.create_provider(papieaUrl, adminKey, server_config.host, server_config.port);
+        try {
+            const location = sdk.new_kind(location_yaml);
+            sdk.version(provider_version);
+            sdk.prefix("location_provider");
+            location.on_create({input_schema: location_yaml}, async (ctx, input) => {
+                expect(input).toBeDefined()
+                return {
+                    spec: input,
+                    status: input
+                }
+            })
+            await sdk.register();
+            const kind_name = sdk.provider.kinds[0].name;
+            const { data: { metadata, spec } } = await axios.post(`${sdk.entity_url}/${sdk.provider.prefix}/${sdk.provider.version}/${kind_name}`, {
+                    x: 10,
+                    y: 11
+            }, {
+                headers: {
+                  "Content-Type": "application/json",
+                  "Authorization": `Bearer ${adminKey}`,
+                  "Papiea-Version": sdk.get_sdk_version()
+                }
+            });
+
+            const updatedEntity: any = await axios.get(`${sdk.entity_url}/${sdk.provider.prefix}/${sdk.provider.version}/${kind_name}/${metadata.uuid}`);
+            expect(updatedEntity.data.spec.x).toEqual(10);
+        } finally {
+            sdk.server.close();
+        }
+    });
+
+    test("Papiea version compatible with the supported version should pass", async () => {
+        expect.hasAssertions();
+        const sdk = ProviderSdk.create_provider(papieaUrl, adminKey, server_config.host, server_config.port);
+        try {
+            const location = sdk.new_kind(location_yaml);
+            sdk.version(provider_version);
+            sdk.prefix("location_provider");
+            location.on_create({input_schema: location_yaml}, async (ctx, input) => {
+                expect(input).toBeDefined()
+                return {
+                    spec: input,
+                    status: input
+                }
+            })
+            await sdk.register();
+            const kind_name = sdk.provider.kinds[0].name;
+            const { data: { metadata, spec } } = await axios.post(`${sdk.entity_url}/${sdk.provider.prefix}/${sdk.provider.version}/${kind_name}`, {
+                    x: 10,
+                    y: 11
+            }, {
+                headers: {
+                  "Content-Type": "application/json",
+                  "Authorization": `Bearer ${adminKey}`,
+                  "Papiea-Version": "0.8.5"
+                }
+            });
+
+            const updatedEntity: any = await axios.get(`${sdk.entity_url}/${sdk.provider.prefix}/${sdk.provider.version}/${kind_name}/${metadata.uuid}`);
+            expect(updatedEntity.data.spec.x).toEqual(10);
+        } finally {
+            sdk.server.close();
+        }
+    });
+
+    test("Papiea version incompatible with the supported version should fail", async () => {
+        expect.hasAssertions();
+        const sdk = ProviderSdk.create_provider(papieaUrl, adminKey, server_config.host, server_config.port);
+        try {
+            const location = sdk.new_kind(location_yaml);
+            sdk.version(provider_version);
+            sdk.prefix("location_provider");
+            location.on_create({input_schema: location_yaml}, async (ctx, input) => {
+                expect(input).toBeDefined()
+                return {
+                    spec: input,
+                    status: input
+                }
+            })
+            await sdk.register();
+            const kind_name = sdk.provider.kinds[0].name;
+            const { data: { metadata, spec } } = await axios.post(`${sdk.entity_url}/${sdk.provider.prefix}/${sdk.provider.version}/${kind_name}`, {
+                    x: 10,
+                    y: 11
+            }, {
+                headers: {
+                  "Content-Type": "application/json",
+                  "Authorization": `Bearer ${adminKey}`,
+                  "Papiea-Version": "1.0.0"
+                }
+            });
+        } catch (e) {
+            expect(e.response.data.error.errors[0].message).toBe("Received incompatible papiea version: 1.0.0")
+        } finally {
+            sdk.server.close();
+        }
+    });
 });
 
 describe("SDK + oauth provider tests", () => {

--- a/papiea-sdk/typescript/src/provider_sdk/typescript_sdk.ts
+++ b/papiea-sdk/typescript/src/provider_sdk/typescript_sdk.ts
@@ -30,7 +30,7 @@ import {
 } from "papiea-core"
 import { LoggerFactory } from 'papiea-backend-utils'
 import { InvocationError, SecurityApiError } from "./typescript_sdk_exceptions"
-import { validate_error_codes } from "./typescript_sdk_utils"
+import { validate_error_codes, get_papiea_version } from "./typescript_sdk_utils"
 
 class SecurityApiImpl implements SecurityApi {
     readonly provider: ProviderSdk;
@@ -98,6 +98,7 @@ export class ProviderSdk implements ProviderImpl {
     protected readonly _securityApi : SecurityApi;
     protected readonly _intentWatcherClient : IntentWatcherClient
     protected allowExtraProps: boolean;
+    protected readonly _sdk_version: Version;
 
     constructor(papiea_url: string, s2skey: Secret, server_manager?: Provider_Server_Manager, allowExtraProps?: boolean) {
         this._version = null;
@@ -122,6 +123,7 @@ export class ProviderSdk implements ProviderImpl {
                 'Authorization': `Bearer ${this._s2skey}`
             }
         });
+        this._sdk_version = get_papiea_version()
     }
 
     get provider() {
@@ -330,6 +332,10 @@ export class ProviderSdk implements ProviderImpl {
 
     public get_intent_watcher_client(): IntentWatcherClient {
         return this._intentWatcherClient
+    }
+
+    public get_sdk_version(): Version {
+        return this._sdk_version;
     }
 }
 

--- a/papiea-sdk/typescript/src/provider_sdk/typescript_sdk_utils.ts
+++ b/papiea-sdk/typescript/src/provider_sdk/typescript_sdk_utils.ts
@@ -10,3 +10,9 @@ export function validate_error_codes(error_desc: ErrorSchemas | undefined) {
         }
     }
 }
+
+export function get_papiea_version(): string {
+    const packageJSON = require('../../package.json');
+    const sdk_version: string = packageJSON.version.split('+')[0];
+    return sdk_version;
+}


### PR DESCRIPTION
- Added get version function in the typescript provider sdk class,
- Defined version header to use in the papiea sdk requests.
- Defined a version check middleware in express validator to validate the sdk version.