### PR TITLE
Removed input tag from the constructor procedure schema in api docs

### DIFF
--- a/papiea-engine/__tests__/docs_tests/api_docs.test.ts
+++ b/papiea-engine/__tests__/docs_tests/api_docs.test.ts
@@ -647,4 +647,38 @@ describe("API docs test entity", () => {
                    .content["application/json"]
                    .schema["$ref"]).toEqual(`#/components/schemas/provider_same_kind_1-0.1.0-InputTwo-Desc-InputOne`);
     });
+    test("Provider kinds with entity constructors should generate correct open api docs", async () => {
+        expect.hasAssertions();
+        const provider: Provider = new ProviderBuilder("provider_kind_with_entity_constructor")
+            .withVersion("0.1.0")
+            .withKinds()
+            .withEntityConstructor()
+            .build();
+        const providerDbMock = new Provider_DB_Mock(provider);
+        const apiDocsGenerator = new ApiDocsGenerator(providerDbMock);
+        const apiDoc = await apiDocsGenerator.getApiDocs(providerDbMock.provider);
+        const kind_name = provider.kinds[0].name;
+
+        // #/components/schemas/provider_kind_with_entity_constructor-0.1.0-object_X5FO9-__object_X5FO9_create-object_X5FO9
+        expect(apiDoc.paths[`/services/${ provider.prefix }/${ provider.version }/${ kind_name }`]
+        .post
+        .requestBody
+        .content["application/json"]
+        .schema['$ref']).toEqual(`#/components/schemas/${ provider.prefix }-${ provider.version }-${ kind_name }-__${ kind_name }_create-${ kind_name }`);
+
+        expect(apiDoc.paths[`/services/${ provider.prefix }/${ provider.version }/${ kind_name }`]
+            .post
+            .responses["200"]
+            .content["application/json"]
+            .schema["$ref"]).toEqual(`#/components/schemas/Nothing`);
+
+        expect(apiDoc.paths[`/services/${ provider.prefix }/${ provider.version }/${ kind_name }`]
+            .post
+            .responses["default"]
+            .content["application/json"]
+            .schema["$ref"]).toEqual(`#/components/schemas/Error`);
+
+        expect(apiDoc.components.schemas[`${ provider.prefix }-${ provider.version }-${ kind_name }-__${ kind_name }_create-${ kind_name }`])
+        .toEqual(provider.kinds[0].kind_structure[kind_name]);
+    });
 });

--- a/papiea-engine/__tests__/test_data_factory.ts
+++ b/papiea-engine/__tests__/test_data_factory.ts
@@ -11,7 +11,8 @@ import {
     Procedural_Execution_Strategy,
     Procedural_Signature,
     Provider,
-    Version
+    Version,
+    Intentful_Execution_Strategy
 } from "papiea-core"
 import * as http from "http"
 import { IncomingMessage, ServerResponse } from "http"
@@ -238,6 +239,28 @@ export class ProviderBuilder {
         } else {
             this._kinds = value;
         }
+        return this;
+    }
+
+    public withEntityConstructor(value?: Procedural_Signature) {
+        if (this._kinds.length < 1) {
+            throw new Error(formatErrorMsg("Entity Procedures", "Kinds"))
+        }
+        const name = `__${ this._kinds[0].name }_create`
+        let procedural_signature: Procedural_Signature
+        if (value === undefined) {
+            procedural_signature = {
+                name,
+                argument: this._kinds[0].kind_structure,
+                result: {},
+                execution_strategy: Intentful_Execution_Strategy.Basic,
+                procedure_callback: "",
+                base_callback: ""
+            };
+        } else {
+            procedural_signature = value
+        }
+        this._kinds[0].kind_procedures[name] = procedural_signature;
         return this;
     }
 

--- a/papiea-engine/src/api_docs/api_docs_generator.ts
+++ b/papiea-engine/src/api_docs/api_docs_generator.ts
@@ -512,11 +512,7 @@ export default class ApiDocsGenerator {
                 "content": {
                     "application/json": {
                         "schema": {
-                            "properties": {
-                                "input": {
-                                    "$ref": `#/components/schemas/${ input }`
-                                }
-                            }
+                            "$ref": `#/components/schemas/${ input }`
                         }
                     }
                 }


### PR DESCRIPTION
Closes #603
- Removed misleading input field tag from the constructor procedure schema function.
- Added WithEntityConstructor function to allow on_create handler in test data factory.