### PR TITLE
Removed dependency on Node env production variable in printing logs

### DIFF
--- a/papiea-backend-utils/src/logging.ts
+++ b/papiea-backend-utils/src/logging.ts
@@ -57,7 +57,7 @@ export class LoggerHandle {
 export type LoggerOptions = {
     logPath?: string,
     level: LogLevel,
-    format: 'json' | 'pretty',
+    pretty_print: boolean,
     verbosity_options: LoggingVerbosityOptions
 }
 
@@ -67,9 +67,6 @@ export class LoggerFactory {
     private static readonly INSPECT_OPTIONS = {
         sorted: true, getters: true, depth: 10,
     }
-
-    private static readonly PRODUCTION =
-        (process?.env?.NODE_ENV === 'production')
 
     public static makeLogger(options: Partial<LoggerOptions>): Logger {
         const factory = new LoggerFactory(options)
@@ -87,7 +84,7 @@ export class LoggerFactory {
     constructor(options: Partial<LoggerOptions>) {
         this.options = LoggerFactory.mergeOptions({
             level: 'info',
-            format: LoggerFactory.PRODUCTION ? 'json' : 'pretty',
+            pretty_print: false,
             verbosity_options: {
                 verbose: false,
                 fields: []
@@ -103,12 +100,12 @@ export class LoggerFactory {
             formatArgs.push(winston.format.label({label: opts.logPath}))
         }
 
-        switch (opts.format) {
-        case 'json':
+        switch (opts.pretty_print) {
+        case false: // json
             formatArgs.push(winston.format.json())
             break
 
-        case 'pretty':
+        case true:  // pretty
             const skip_fields = ['level','timestamp','label','message','stack']
 
             formatArgs.push(winston.format.errors({stack: true}))
@@ -170,7 +167,7 @@ export class LoggerFactory {
                                           : opt.logPath
             }
             if (opt.level) res.level = opt.level
-            if (opt.format) res.format = opt.format
+            if (opt.pretty_print) res.pretty_print = opt.pretty_print
             if (opt.verbosity_options) res.verbosity_options = opt.verbosity_options
             return res
         }, Object.assign({}, first))

--- a/papiea-engine/papiea-config.yaml
+++ b/papiea-engine/papiea-config.yaml
@@ -1,2 +1,3 @@
 debug: true
 diff_retry_exponent: 1.3
+pretty_print: true

--- a/papiea-engine/src/diff_resolver_main.ts
+++ b/papiea-engine/src/diff_resolver_main.ts
@@ -24,9 +24,10 @@ const intentResolveDelay = config.intent_resolve_delay
 const diffResolveDelay = config.diff_resolve_delay
 const diffRetryExponent = config.diff_retry_exponent
 const verbosityOptions = config.logging_verbosity
+const prettyPrint = config.pretty_print
 
 async function setUpDiffResolver() {
-    const logger = LoggerFactory.makeLogger({level: loggingLevel, verbosity_options: verbosityOptions});
+    const logger = LoggerFactory.makeLogger({level: loggingLevel, verbosity_options: verbosityOptions, pretty_print: prettyPrint});
     const mongoConnection: MongoConnection = new MongoConnection(mongoUrl, mongoDb);
     await mongoConnection.connect();
 

--- a/papiea-engine/src/main.ts
+++ b/papiea-engine/src/main.ts
@@ -42,10 +42,11 @@ const adminKey = config.admin_key
 const loggingLevel = logLevelFromString(config.logging_level)
 const papieaDebug = config.debug
 const verbosityOptions = config.logging_verbosity
+const prettyPrint = config.pretty_print
 const tracingConfig = config.tracing_config
 
 async function setUpApplication(): Promise<express.Express> {
-    const logger = LoggerFactory.makeLogger({level: loggingLevel, verbosity_options: verbosityOptions});
+    const logger = LoggerFactory.makeLogger({level: loggingLevel, verbosity_options: verbosityOptions, pretty_print: prettyPrint});
     const tracer = getTracer("papiea-engine", logger, tracingConfig.reporter, tracingConfig.sampler, tracingConfig.logMessages)
     const trace = getTracingMiddleware(tracer)
     const auditLogger: AuditLogger = new AuditLogger(logger, papieaDebug)

--- a/papiea-engine/src/utils/arg_parser.ts
+++ b/papiea-engine/src/utils/arg_parser.ts
@@ -72,6 +72,7 @@ const TRANSFORM_FN_MAP: { [key in keyof PapieaConfig]: (val: any) => PapieaConfi
     mongo_db: toStr,
     admin_key: toStr,
     logging_level: toStr,
+    pretty_print: toBool,
     logging_verbosity: toComplexLoggingVerbosity,
     tracing_config: toComplexTracingConfig
 }
@@ -99,6 +100,9 @@ export interface PapieaConfig {
 
     // Default logging level for papiea
     logging_level: string,
+
+    // Pretty print logs flag for papiea (pretty or json)
+    pretty_print: boolean,
 
     // Size of batch of random entities to be added to diff resolution each N seconds
     entity_batch_size: number,
@@ -132,6 +136,7 @@ const PAPIEA_DEFAULT_CFG: PapieaConfig = {
     admin_key: "",
     debug: true,
     logging_level: "info",
+    pretty_print: false,
     entity_batch_size: 5,
     deleted_watcher_persist_time: 100,
     entity_poll_delay: 250,

--- a/papiea-sdk/typescript/__tests__/client_e2e_tests/utils.ts
+++ b/papiea-sdk/typescript/__tests__/client_e2e_tests/utils.ts
@@ -1,7 +1,7 @@
 import { LoggerFactory } from "papiea-backend-utils";
 
 const logger_factory = new LoggerFactory({logPath: "e2e_tests"})
-export const [logger, _] = logger_factory.createLogger({level: "debug"})
+export const [logger, _] = logger_factory.createLogger({level: "debug", pretty_print: true})
 
 export function get_kind_ref_type(kind: string, description: string = "") {
     return {

--- a/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
+++ b/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
@@ -1589,7 +1589,7 @@ describe("SDK + oauth provider tests", () => {
     const kind_name = provider.kinds[0].name;
     let entity_metadata: Metadata, entity_spec: Spec;
     const oauth2Server = OAuth2Server.createServer();
-    const providerSDKTestLogger = LoggerFactory.makeLogger({level: "info"});
+    const providerSDKTestLogger = LoggerFactory.makeLogger({level: "info", pretty_print: true});
 
     beforeAll(async () => {
         await providerApiAdmin.post('/', provider);

--- a/papiea-sdk/typescript/src/provider_sdk/typescript_sdk.ts
+++ b/papiea-sdk/typescript/src/provider_sdk/typescript_sdk.ts
@@ -607,7 +607,7 @@ export class Kind_Builder {
     on_create(description: {input_schema?: any, error_schemas?: ErrorSchemas}, handler: (ctx: ProceduralCtx_Interface, input: any) => Promise<{spec: Spec, status: Status, metadata?: Partial<Metadata>}>): Kind_Builder {
         const name = `__${this.kind.name}_create`
         const loggerFactory = new LoggerFactory({logPath: name})
-        const [logger, handle] = loggerFactory.createLogger()
+        const [logger, handle] = loggerFactory.createLogger({pretty_print: true})
         logger.info(`You are registering on create handler for kind: ${this.kind.name}. Note, this is a post create handler. The behaviour is due to change`)
         if (!description.input_schema) {
             logger.info(`Input schema is undefined for on_create handler, using the schema for kind: ${this.kind.name}`)
@@ -621,7 +621,7 @@ export class Kind_Builder {
     on_delete(handler: (ctx: ProceduralCtx_Interface, entity: Partial<Entity>) => Promise<void>): Kind_Builder {
         const name = `__${this.kind.name}_delete`
         const loggerFactory = new LoggerFactory({logPath: name})
-        const [logger, handle] = loggerFactory.createLogger()
+        const [logger, handle] = loggerFactory.createLogger({pretty_print: true})
         logger.info(`You are registering on delete handler for kind: ${this.kind.name}. Note, this is a pre delete handler. The behaviour is due to change`)
         handle.cleanup()
         this.kind_procedure(name, {}, handler)

--- a/papiea-sdk/typescript/src/provider_sdk/typescript_sdk_context_impl.ts
+++ b/papiea-sdk/typescript/src/provider_sdk/typescript_sdk_context_impl.ts
@@ -124,7 +124,7 @@ export class ProceduralCtx implements ProceduralCtx_Interface {
     }
 
     get_logger(level?: LogLevel): Logger {
-        const [logger, handle] = this.loggerFactory.createLogger({level})
+        const [logger, handle] = this.loggerFactory.createLogger({level, pretty_print: true})
         this.loggerHandles.push(handle)
         return logger
     }


### PR DESCRIPTION
Closes #640
- Added support for pretty print config variable.
- Modified LoggerOptions to use pretty print flag to replace the format variable.
- Set pretty print to true for papiea use.