### PR TITLE
Pass recent entity info to destructors/intent handlers

### DIFF
--- a/papiea-engine/src/intentful_core/intentful_strategies/intentful_strategy_interface.ts
+++ b/papiea-engine/src/intentful_core/intentful_strategies/intentful_strategy_interface.ts
@@ -49,7 +49,7 @@ export abstract class IntentfulStrategy {
         return null
     }
 
-    protected async invoke_destructor(procedure_name: string, entity: Partial<Entity>, ctx: RequestContext): Promise<void> {
+    protected async invoke_destructor(procedure_name: string, entity: Entity, ctx: RequestContext): Promise<void> {
         if (this.kind) {
             if (this.kind.kind_procedures[procedure_name]) {
                 if (this.user === undefined) {
@@ -82,7 +82,7 @@ export abstract class IntentfulStrategy {
     }
 
     async delete(entity: Entity, ctx: RequestContext): Promise<void> {
-        await this.invoke_destructor(`__${entity.metadata.kind}_delete`, { metadata: entity.metadata }, ctx)
+        await this.invoke_destructor(`__${entity.metadata.kind}_delete`, entity, ctx)
         const span = spanOperation(`delete_entity_db`,
                                    ctx.tracing_ctx,
                                    {entity_uuid: entity.metadata.uuid})

--- a/papiea-engine/src/intentful_core/sfs_compiler.ts
+++ b/papiea-engine/src/intentful_core/sfs_compiler.ts
@@ -2,6 +2,7 @@ import { ValidationError } from "../errors/validation_error"
 import {DiffContent, Spec, Status} from "papiea-core"
 import { PapieaException } from "../errors/papiea_exception";
 import { Logger } from "papiea-backend-utils";
+import { cloneDeep } from "lodash"
 
 // TODO: add d.ts for type annotations
 const papi_clj = require("../../papiea-lib-clj/papiea-lib-clj.js").papiea_lib_clj;
@@ -88,7 +89,8 @@ function cleanup_spec_for_sfs_run(spec: Spec, kind_name: string, logger?: Logger
     } else {
         console.debug(`Running sanitizer function for ${kind_name}/spec.`)
     }
-    const diff_spec = remove_undefined_or_null_values(spec, logger, kind_name, "spec")
+    let diff_spec = JSON.parse(JSON.stringify(spec))
+    diff_spec = remove_undefined_or_null_values(diff_spec, logger, kind_name, "spec")
     return diff_spec
 }
 
@@ -98,7 +100,8 @@ function cleanup_status_for_sfs_run(status: Status, schema: any, kind_name: stri
     } else {
         console.debug(`Running sanitizer function for ${kind_name}/status.`)
     }
-    let diff_status = remove_undefined_or_null_values(status, logger, kind_name, "status")
+    let diff_status = JSON.parse(JSON.stringify(status))
+    diff_status = remove_undefined_or_null_values(diff_status, logger, kind_name, "status")
     diff_status = remove_status_only_fields(schema, diff_status)
     return diff_status
 }

--- a/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
+++ b/papiea-sdk/typescript/__tests__/sdk_tests/provider_sdk.test.ts
@@ -2197,6 +2197,9 @@ describe("SDK callback tests", () => {
         );
         location.on_delete(async (ctx, input) => {
             expect(input).toBeDefined()
+            expect(input.metadata).toBeDefined()
+            expect(input.spec).toBeDefined()
+            expect(input.status).toBeDefined()
         })
         try {
             await sdk.register()

--- a/papiea-sdk/typescript/src/provider_sdk/typescript_sdk.ts
+++ b/papiea-sdk/typescript/src/provider_sdk/typescript_sdk.ts
@@ -792,7 +792,7 @@ export class Kind_Builder {
         return this
     }
 
-    on_delete(handler: (ctx: ProceduralCtx_Interface, entity: Partial<Entity>) => Promise<void>): Kind_Builder {
+    on_delete(handler: (ctx: ProceduralCtx_Interface, entity: Entity) => Promise<void>): Kind_Builder {
         const name = `__${this.kind.name}_delete`
         const loggerFactory = new LoggerFactory({logPath: name})
         const [logger, handle] = loggerFactory.createLogger()


### PR DESCRIPTION
Closes #675
- Fixed deep copy bug in differ sanitizer functions
- Modified destructor handler input to include the complete entity structure.