### PR TITLE
Fix OOM issue && Use AsyncIterators to fetch intent watchers

### DIFF
--- a/papiea-engine/Dockerfile
+++ b/papiea-engine/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y wget curl openjdk-11-jdk \
     # For nodejs
     && apt-get install -y gnupg \
-    && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_15.x | bash - \
     && apt-get install -y nodejs \
     # For python3.8
     && apt-get install -y python3.8 python3-pip python3.8-dev \

--- a/papiea-engine/__tests__/database_tests/database_mongo.test.ts
+++ b/papiea-engine/__tests__/database_tests/database_mongo.test.ts
@@ -574,8 +574,10 @@ describe("MongoDb tests", () => {
             entity_ref: {} as Provider_Entity_Reference,
         };
         await watcherDb.save_watcher(watcher);
-        const res = (await watcherDb.list_watchers({ uuid: watcher.uuid }) as IntentWatcher[])[0]
-        expect(res.uuid).toEqual(watcher.uuid);
+        const watcher_cursor = watcherDb.list_watchers({ uuid: watcher.uuid })
+        const res = await watcher_cursor.next()
+        expect(res!.uuid).toEqual(watcher.uuid);
+        await watcher_cursor.close()
         await watcherDb.delete_watcher(watcher.uuid)
     });
 

--- a/papiea-engine/__tests__/entity_tests/sorting.test.ts
+++ b/papiea-engine/__tests__/entity_tests/sorting.test.ts
@@ -2,6 +2,7 @@ import { ProviderBuilder } from "../test_data_factory";
 import axios from "axios";
 import { UserAuthInfo } from "../../src/auth/authn";
 import { Authorizer } from "../../src/auth/authz";
+import * as Async from "../../src/utils/async";
 import { Action } from "papiea-core";
 import { LoggerFactory } from 'papiea-backend-utils';
 
@@ -101,7 +102,7 @@ describe("Pagination tests", () => {
     test("Authorizer doesn't affect the order of sorting", async () => {
         const authorizer = new MockedAuthorizer();
         const specs = [{spec: {x: 10, y: 11}}, {spec: {x: 18, y:27}}, {spec: {x: 22, y: 8}}, {spec: {x: 41, y: 50}}];
-        const res = await authorizer.filter(LoggerFactory.makeLogger({}), {} as UserAuthInfo, specs, {} as Action);
+        const res = await Async.collect(authorizer.filter(LoggerFactory.makeLogger({}), {} as UserAuthInfo, specs, {} as Action));
         for (let i = 0; i < res.length - 1; i++) {
             expect(res[i+1].spec.x).toBeGreaterThan(res[i].spec.x)
         }

--- a/papiea-engine/src/auth/authz.ts
+++ b/papiea-engine/src/auth/authz.ts
@@ -5,15 +5,7 @@ import {Action, Provider, IntentWatcher, Entity, Provider_Entity_Reference} from
 import {PermissionDeniedError, UnauthorizedError} from "../errors/permission_error"
 import {BadRequestError} from "../errors/bad_request_error"
 import {Logger} from "papiea-backend-utils"
-
-function mapAsync<T, U>(array: T[], callbackfn: (value: T, index: number, array: T[]) => Promise<U>): Promise<U[]> {
-    return Promise.all(array.map(callbackfn));
-}
-
-async function filterAsync<T>(array: T[], callbackfn: (value: T, index: number, array: T[]) => Promise<boolean>): Promise<T[]> {
-    const filterMap = await mapAsync(array, callbackfn);
-    return array.filter((value, index) => filterMap[index]);
-}
+import * as Async from '../utils/async'
 
 export abstract class Authorizer {
     constructor() {
@@ -21,8 +13,8 @@ export abstract class Authorizer {
 
     abstract checkPermission(user: UserAuthInfo, object: any, action: Action, provider?: Provider): Promise<void>;
 
-    async filter(logger: Logger, user: UserAuthInfo, objectList: any[], action: Action, provider?: Provider, transformfn?: (object: any) => any): Promise<any[]> {
-        return filterAsync(objectList, async (object) => {
+    filter<T>(logger: Logger, user: UserAuthInfo, objectList: Async.AnyIterable<T>, action: Action, provider?: Provider, transformfn?: (object: any) => any): AsyncIterable<T> {
+        return Async.filter(objectList, async (object) => {
             try {
                 if (transformfn) {
                     await this.checkPermission(user, transformfn(object), action, provider);

--- a/papiea-engine/src/databases/intent_watcher_db_interface.ts
+++ b/papiea-engine/src/databases/intent_watcher_db_interface.ts
@@ -5,7 +5,7 @@ export interface IntentWatcher_DB {
 
     save_watcher(watcher: IntentWatcher): Promise<void>
 
-    list_watchers(fields_map: any, sortParams?: SortParams): Promise<IntentWatcher[]>
+    list_watchers(fields_map: any, sortParams?: SortParams): AsyncIterable<IntentWatcher>
 
     get_watcher(uuid: string): Promise<IntentWatcher>
 

--- a/papiea-engine/src/databases/intent_watcher_db_interface.ts
+++ b/papiea-engine/src/databases/intent_watcher_db_interface.ts
@@ -1,11 +1,12 @@
 import { SortParams } from "../entity/entity_api_impl"
 import { IntentWatcher } from "papiea-core"
+import { Cursor } from "mongodb"
 
 export interface IntentWatcher_DB {
 
     save_watcher(watcher: IntentWatcher): Promise<void>
 
-    list_watchers(fields_map: any, sortParams?: SortParams): AsyncIterable<IntentWatcher>
+    list_watchers(fields_map: any, sortParams?: SortParams): Cursor<IntentWatcher>
 
     get_watcher(uuid: string): Promise<IntentWatcher>
 

--- a/papiea-engine/src/databases/intent_watcher_db_mongo.ts
+++ b/papiea-engine/src/databases/intent_watcher_db_mongo.ts
@@ -56,12 +56,12 @@ export class IntentWatcher_DB_Mongo implements IntentWatcher_DB {
     }
 
 
-    async list_watchers(fields_map: any, sortParams?: SortParams): Promise<IntentWatcher[]> {
+    list_watchers(fields_map: any, sortParams?: SortParams): AsyncIterable<IntentWatcher> {
         const filter: any = Object.assign({}, fields_map);
         if (sortParams) {
-            return await this.collection.find(filter).sort(sortParams).toArray();
+            return this.collection.find(filter).sort(sortParams);
         } else {
-            return await this.collection.find(filter).toArray();
+            return this.collection.find(filter);
         }
     }
 

--- a/papiea-engine/src/databases/intent_watcher_db_mongo.ts
+++ b/papiea-engine/src/databases/intent_watcher_db_mongo.ts
@@ -1,4 +1,4 @@
-import { Collection, Db } from "mongodb"
+import { Collection, Db, Cursor } from "mongodb"
 import { SortParams } from "../entity/entity_api_impl"
 import { Logger } from 'papiea-backend-utils'
 import { IntentWatcher_DB } from "./intent_watcher_db_interface"
@@ -56,7 +56,7 @@ export class IntentWatcher_DB_Mongo implements IntentWatcher_DB {
     }
 
 
-    list_watchers(fields_map: any, sortParams?: SortParams): AsyncIterable<IntentWatcher> {
+    list_watchers(fields_map: any, sortParams?: SortParams): Cursor<IntentWatcher> {
         const filter: any = Object.assign({}, fields_map);
         if (sortParams) {
             return this.collection.find(filter).sort(sortParams);

--- a/papiea-engine/src/entity/entity_api_impl.ts
+++ b/papiea-engine/src/entity/entity_api_impl.ts
@@ -28,7 +28,7 @@ import {Provider_DB} from "../databases/provider_db_interface"
 import {IntentWatcherMapper} from "../intentful_engine/intent_interface"
 import {IntentWatcher_DB} from "../databases/intent_watcher_db_interface"
 import {Graveyard_DB} from "../databases/graveyard_db_interface"
-import * as Async from "../utils/async"
+import { Cursor } from "mongodb"
 
 export type SortParams = { [key: string]: number };
 
@@ -72,11 +72,10 @@ export class Entity_API_Impl implements Entity_API {
         return IntentWatcherMapper.toResponse(intent_watcher)
     }
 
-    filter_intent_watcher(user: UserAuthInfo, fields: any, ctx: RequestContext, sortParams?: SortParams): AsyncIterable<Partial<IntentWatcher>> {
+    filter_intent_watcher(user: UserAuthInfo, fields: any, ctx: RequestContext, sortParams?: SortParams): [AsyncIterable<Partial<IntentWatcher>>, Cursor<IntentWatcher>] {
         const watcher_cursor = this.intent_watcher_db.list_watchers(fields, sortParams)
         const filteredRes = this.intentWatcherAuthorizer.filter(this.logger, user, watcher_cursor, Action.Read);
-        watcher_cursor.close()
-        return IntentWatcherMapper.toResponses(filteredRes)
+        return [IntentWatcherMapper.toResponses(filteredRes), watcher_cursor]
     }
 
     async save_entity(user: UserAuthInfo, prefix: string, kind_name: string, version: Version, input: unknown, ctx: RequestContext): Promise<EntityCreateOrUpdateResult> {

--- a/papiea-engine/src/entity/entity_api_impl.ts
+++ b/papiea-engine/src/entity/entity_api_impl.ts
@@ -73,8 +73,9 @@ export class Entity_API_Impl implements Entity_API {
     }
 
     filter_intent_watcher(user: UserAuthInfo, fields: any, ctx: RequestContext, sortParams?: SortParams): AsyncIterable<Partial<IntentWatcher>> {
-        const intent_watchers = this.intent_watcher_db.list_watchers(fields, sortParams)
-        const filteredRes = this.intentWatcherAuthorizer.filter(this.logger, user, intent_watchers, Action.Read);
+        const watcher_cursor = this.intent_watcher_db.list_watchers(fields, sortParams)
+        const filteredRes = this.intentWatcherAuthorizer.filter(this.logger, user, watcher_cursor, Action.Read);
+        watcher_cursor.close()
         return IntentWatcherMapper.toResponses(filteredRes)
     }
 

--- a/papiea-engine/src/entity/entity_api_interface.ts
+++ b/papiea-engine/src/entity/entity_api_interface.ts
@@ -2,6 +2,7 @@ import { UserAuthInfo } from "../auth/authn";
 import { Version, Spec, Metadata, uuid4, Status, Entity_Reference, Action, Entity, EntityCreateOrUpdateResult, IntentWatcher } from "papiea-core";
 import { SortParams } from "./entity_api_impl";
 import {RequestContext} from "papiea-backend-utils"
+import { Cursor } from "mongodb";
 
 export interface Entity_API {
     save_entity(user: UserAuthInfo, prefix: string, kind_name: string, version: Version, input: unknown, context: RequestContext): Promise<EntityCreateOrUpdateResult>
@@ -12,7 +13,7 @@ export interface Entity_API {
 
     get_entity_status(user: UserAuthInfo, prefix: string, version: Version, kind_name: string, entity_uuid: uuid4, context: RequestContext): Promise<[Metadata, Status]>
 
-    filter_intent_watcher(user: UserAuthInfo, fields: any, context: RequestContext, sortParams?: SortParams): AsyncIterable<Partial<IntentWatcher>>
+    filter_intent_watcher(user: UserAuthInfo, fields: any, context: RequestContext, sortParams?: SortParams): [AsyncIterable<Partial<IntentWatcher>>, Cursor<IntentWatcher>]
 
     filter_entity_spec(user: UserAuthInfo, prefix: string, version: Version, kind_name: string, fields: any, exact_match: boolean, context: RequestContext, sortParams?: SortParams): AsyncIterable<[Metadata, Spec]>
 

--- a/papiea-engine/src/entity/entity_api_interface.ts
+++ b/papiea-engine/src/entity/entity_api_interface.ts
@@ -12,13 +12,13 @@ export interface Entity_API {
 
     get_entity_status(user: UserAuthInfo, prefix: string, version: Version, kind_name: string, entity_uuid: uuid4, context: RequestContext): Promise<[Metadata, Status]>
 
-    filter_intent_watcher(user: UserAuthInfo, fields: any, context: RequestContext, sortParams?: SortParams): Promise<Partial<IntentWatcher>[]>
+    filter_intent_watcher(user: UserAuthInfo, fields: any, context: RequestContext, sortParams?: SortParams): AsyncIterable<Partial<IntentWatcher>>
 
-    filter_entity_spec(user: UserAuthInfo, prefix: string, version: Version, kind_name: string, fields: any, exact_match: boolean, context: RequestContext, sortParams?: SortParams): Promise<[Metadata, Spec][]>
+    filter_entity_spec(user: UserAuthInfo, prefix: string, version: Version, kind_name: string, fields: any, exact_match: boolean, context: RequestContext, sortParams?: SortParams): AsyncIterable<[Metadata, Spec]>
 
-    filter_entity_status(user: UserAuthInfo, prefix: string, version: Version, kind_name: string, fields: any, exact_match: boolean, context: RequestContext, sortParams?: SortParams): Promise<[Metadata, Status][]>
+    filter_entity_status(user: UserAuthInfo, prefix: string, version: Version, kind_name: string, fields: any, exact_match: boolean, context: RequestContext, sortParams?: SortParams): AsyncIterable<[Metadata, Status]>
 
-    filter_deleted(user: UserAuthInfo, prefix: string, version: Version, kind_name: string, fields: any, exact_match: boolean, context: RequestContext, sortParams?: SortParams): Promise<Entity[]>
+    filter_deleted(user: UserAuthInfo, prefix: string, version: Version, kind_name: string, fields: any, exact_match: boolean, context: RequestContext, sortParams?: SortParams): AsyncIterable<Entity>
 
     update_entity_spec(user: UserAuthInfo, uuid: uuid4, prefix: string, spec_version: number, extension: {[key: string]: any}, kind_name: string, version: Version, spec_description: Spec, context: RequestContext): Promise<EntityCreateOrUpdateResult>
 

--- a/papiea-engine/src/entity/entity_routes.ts
+++ b/papiea-engine/src/entity/entity_routes.ts
@@ -80,8 +80,9 @@ export function createEntityAPIRouter(entity_api: Entity_API, trace: Function): 
         if (req.query.status) {
             filter.status = req.query.status
         }
-        const intent_watchers = await Async.collect(
-            entity_api.filter_intent_watcher(req.user, filter, res.locals.ctx, sortParams))
+        const [watcher_iter, watcher_cursor] = entity_api.filter_intent_watcher(req.user, filter, res.locals.ctx, sortParams)
+        const intent_watchers = await Async.collect(watcher_iter)
+        await watcher_cursor.close()
         res.json(paginateEntities(intent_watchers, skip, size))
     }))
 
@@ -104,8 +105,9 @@ export function createEntityAPIRouter(entity_api: Entity_API, trace: Function): 
         if (req.body.status) {
             filter.status = req.body.status
         }
-        const intent_watchers = await Async.collect(
-            entity_api.filter_intent_watcher(req.user, filter, res.locals.ctx, sortParams))
+        const [watcher_iter, watcher_cursor] = entity_api.filter_intent_watcher(req.user, filter, res.locals.ctx, sortParams)
+        const intent_watchers = await Async.collect(watcher_iter)
+        await watcher_cursor.close()
         res.json(paginateEntities(intent_watchers, skip, size))
     }))
 

--- a/papiea-engine/src/entity/entity_routes.ts
+++ b/papiea-engine/src/entity/entity_routes.ts
@@ -8,47 +8,49 @@ import { SortParams } from "./entity_api_impl";
 import { CheckNoQueryParams, check_request } from "../validator/express_validator";
 import {Version} from "papiea-core"
 import {RequestContext} from "papiea-backend-utils"
+import * as Async from "../utils/async"
 
 const CheckProcedureCallParams = check_request({
     allowed_query_params: []
 });
 
-interface PaginatedResult {
-    results: any[],
+interface PaginatedResult<T> {
+    results: T[],
     entity_count: number
 }
 
 export function createEntityAPIRouter(entity_api: Entity_API, trace: Function): Router {
     const router = Router();
 
-    const paginateEntities = async function(entities: any, skip: number, size: number): Promise<PaginatedResult> {
+    const paginateEntities = function<T>(entities: T[], skip: number, size: number): PaginatedResult<T> {
         const totalEntities: number = entities.length;
         const pageEntities = entities.slice(skip, skip + size);
 
         return { results: pageEntities, entity_count: totalEntities };
     }
 
-    const filterEntities = async (user: UserAuthInfo, prefix: string, version: Version, kind_name: string, filter: any, skip: number, size: number, searchDeleted: boolean, exactMatch: boolean, ctx: RequestContext, sortParams?: SortParams): Promise<any> => {
+    const filterEntities = async (user: UserAuthInfo, prefix: string, version: Version, kind_name: string, filter: any, skip: number, size: number, searchDeleted: boolean, exactMatch: boolean, ctx: RequestContext, sortParams?: SortParams): Promise<PaginatedResult<any>> => {
         if (searchDeleted) {
-            const entities = await entity_api.filter_deleted(user, prefix, version, kind_name, filter, exactMatch, ctx, sortParams)
-            return paginateEntities(Object.values(entities), skip, size)
+            const entities = await Async.collect(
+                entity_api.filter_deleted(user, prefix, version, kind_name, filter, exactMatch, ctx, sortParams))
+            return paginateEntities(entities, skip, size)
         }
-        const resultSpecs: any[] = await entity_api.filter_entity_spec(user, prefix, version, kind_name, filter, exactMatch, ctx, sortParams);
 
-        const resultStatuses: any[] = await entity_api.filter_entity_status(user, prefix, version, kind_name, filter, exactMatch, ctx, sortParams);
+        const resultSpecs = entity_api.filter_entity_spec(
+            user, prefix, version, kind_name, filter, exactMatch, ctx, sortParams);
+        const resultStatuses = entity_api.filter_entity_status(
+            user, prefix, version, kind_name, filter, exactMatch, ctx, sortParams);
 
-        const uuidToEntity: { [key: string]: any } = {};
+        const uuidToEntity = new Map<string, any>();
+        for await (const x of resultSpecs) {
+            uuidToEntity.set(x[0].uuid, {metadata: x[0], spec: x[1]});
+        }
+        for await (const x of resultStatuses) {
+            const e = uuidToEntity.get(x[0].uuid);
+            if (e) e.status = x[1];
+        }
 
-        resultSpecs.forEach(x => {
-            uuidToEntity[x[0].uuid] = { metadata: x[0], spec: x[1] };
-        });
-
-        resultStatuses.forEach(x => {
-            if (uuidToEntity[x[0].uuid] !== undefined)
-                uuidToEntity[x[0].uuid].status = x[1];
-        });
-
-        const entities = Object.values(uuidToEntity);
+        const entities = Array.from(uuidToEntity.values());
         return paginateEntities(entities, skip, size)
     };
 
@@ -78,8 +80,9 @@ export function createEntityAPIRouter(entity_api: Entity_API, trace: Function): 
         if (req.query.status) {
             filter.status = req.query.status
         }
-        const intent_watchers = await entity_api.filter_intent_watcher(req.user, filter, res.locals.ctx, sortParams)
-        res.json(await paginateEntities(intent_watchers, skip, size))
+        const intent_watchers = await Async.collect(
+            entity_api.filter_intent_watcher(req.user, filter, res.locals.ctx, sortParams))
+        res.json(paginateEntities(intent_watchers, skip, size))
     }))
 
     router.post("/intent_watcher/filter", check_request({
@@ -101,8 +104,9 @@ export function createEntityAPIRouter(entity_api: Entity_API, trace: Function): 
         if (req.body.status) {
             filter.status = req.body.status
         }
-        const intent_watchers = await entity_api.filter_intent_watcher(req.user, filter, res.locals.ctx, sortParams)
-        res.json(await paginateEntities(intent_watchers, skip, size))
+        const intent_watchers = await Async.collect(
+            entity_api.filter_intent_watcher(req.user, filter, res.locals.ctx, sortParams))
+        res.json(paginateEntities(intent_watchers, skip, size))
     }))
 
     router.get("/:prefix/:version/:kind", check_request({

--- a/papiea-engine/src/intentful_engine/intent_interface.ts
+++ b/papiea-engine/src/intentful_engine/intent_interface.ts
@@ -1,4 +1,5 @@
 import { Metadata, Spec, IntentWatcher } from "papiea-core"
+import * as Async from "../utils/async"
 
 export class IntentWatcherMapper {
     public static toResponse(intentWatcher: IntentWatcher): Partial<IntentWatcher> {
@@ -11,27 +12,18 @@ export class IntentWatcherMapper {
         }
     }
 
-    public static filter(intentWatchers: IntentWatcher[], entities: [Metadata, Spec][]): IntentWatcher[] {
-        const watchers: IntentWatcher[] = []
-        entities.forEach(entity => {
-            intentWatchers.forEach(watcher => {
-                if (entity[0].uuid === watcher.entity_ref.uuid && !watchers.includes(watcher)) {
-                    watchers.push(watcher)
-                }
-            })
-        })
-        return watchers
+    public static filter(intentWatchers: AsyncIterable<IntentWatcher>, entities: [Metadata, Spec][]): AsyncIterable<IntentWatcher> {
+        return Async.filter(intentWatchers, async watcher =>
+            !!entities.find(entity => entity[0].uuid === watcher.entity_ref.uuid));
     }
 
-    public static toResponses(intentWatchers: IntentWatcher[]): Partial<IntentWatcher>[] {
-        return intentWatchers.map(watcher => {
-            return {
+    public static toResponses(intentWatchers: AsyncIterable<IntentWatcher>): AsyncIterable<Partial<IntentWatcher>> {
+        return Async.map(intentWatchers, async watcher => ({
                 uuid: watcher.uuid,
                 entity_ref: watcher.entity_ref,
                 spec_version: watcher.spec_version,
                 status: watcher.status,
                 created_at: watcher.created_at
-            }
-        })
+            }))
     }
 }

--- a/papiea-engine/src/intentful_engine/intent_resolver.ts
+++ b/papiea-engine/src/intentful_engine/intent_resolver.ts
@@ -44,9 +44,11 @@ export class IntentResolver {
         for (let diff of current_diffs) {
             for (let idx in watcher_diff.diff_fields) {
                 const watcher_diff_path = JSON.stringify(watcher_diff.diff_fields[idx].path)
-                const current_diff_path = JSON.stringify(diff.diff_fields[idx].path)
-                if (watcher_diff_path === current_diff_path) {
-                    return diff
+                for (let current_diff_idx in diff.diff_fields) {
+                    const current_diff_path = JSON.stringify(diff.diff_fields[current_diff_idx].path)
+                    if (watcher_diff_path === current_diff_path) {
+                        return diff
+                    }
                 }
             }
         }

--- a/papiea-engine/src/intentful_engine/intent_resolver.ts
+++ b/papiea-engine/src/intentful_engine/intent_resolver.ts
@@ -7,6 +7,7 @@ import {Watchlist} from "./watchlist"
 import {Diff, DiffContent, Differ, Entity, IntentfulStatus, IntentWatcher} from "papiea-core"
 import {timeout} from "../utils/utils"
 import {Logger} from "papiea-backend-utils"
+import { Cursor } from "mongodb"
 
 export class IntentResolver {
     private readonly specDb: Spec_DB
@@ -68,14 +69,15 @@ export class IntentResolver {
     }
 
     private async clearTerminalStateWatchers(watcherExpirySeconds: number) {
-        const watchers = this.intentWatcherDb.list_watchers({})
-        for await (let watcher of watchers) {
+        const watcher_cursor = this.intentWatcherDb.list_watchers({})
+        for await (let watcher of watcher_cursor) {
             if (IntentResolver.inTerminalState(watcher)) {
                 if (watcher.last_status_changed && (new Date().getTime() - watcher.last_status_changed.getTime()) / 1000 > watcherExpirySeconds) {
                     await this.intentWatcherDb.delete_watcher(watcher.uuid)
                 }
             }
         }
+        await watcher_cursor.close()
     }
 
     private async rediff(entity: Entity): Promise<Diff[]> {
@@ -137,8 +139,9 @@ export class IntentResolver {
     }
 
     private async onChange(entity: Entity) {
+        let watcher_cursor: Cursor<IntentWatcher>
         try {
-            const watchers = this.intentWatcherDb.list_watchers(
+            watcher_cursor = this.intentWatcherDb.list_watchers(
                 {
                     entity_ref: {
                         uuid: entity.metadata.uuid,
@@ -149,10 +152,12 @@ export class IntentResolver {
                     status: IntentfulStatus.Active
                 }
             )
-            for await (const watcher of watchers) {
+            for await (const watcher of watcher_cursor) {
                 await this.processActiveWatcher(watcher, entity)
             }
+            await watcher_cursor.close()
         } catch (e) {
+            await watcher_cursor!.close()
             this.logger.debug(`Couldn't process onChange for entity`, {
                 error: e.toString(),
                 stack: e.stack,
@@ -168,7 +173,7 @@ export class IntentResolver {
                 continue
             }
             const [entry_ref, _] = entries[key]
-            const watchers = this.intentWatcherDb.list_watchers(
+            const watcher_cursor = this.intentWatcherDb.list_watchers(
                 {
                     entity_ref: {
                         uuid: entry_ref.entity_reference.uuid,
@@ -179,7 +184,8 @@ export class IntentResolver {
                     status: IntentfulStatus.Active
                 }
             )
-            const hasWatcher = ! (await watchers[Symbol.asyncIterator]().next()).done;
+            const hasWatcher = ! (await watcher_cursor[Symbol.asyncIterator]().next()).done;
+            await watcher_cursor.close()
             if (hasWatcher) {
                 try {
                     const [, spec] = await this.specDb.get_spec({...entry_ref.provider_reference, ...entry_ref.entity_reference})

--- a/papiea-engine/src/intentful_engine/intent_resolver.ts
+++ b/papiea-engine/src/intentful_engine/intent_resolver.ts
@@ -68,8 +68,8 @@ export class IntentResolver {
     }
 
     private async clearTerminalStateWatchers(watcherExpirySeconds: number) {
-        const watchers = await this.intentWatcherDb.list_watchers({})
-        for (let watcher of watchers) {
+        const watchers = this.intentWatcherDb.list_watchers({})
+        for await (let watcher of watchers) {
             if (IntentResolver.inTerminalState(watcher)) {
                 if (watcher.last_status_changed && (new Date().getTime() - watcher.last_status_changed.getTime()) / 1000 > watcherExpirySeconds) {
                     await this.intentWatcherDb.delete_watcher(watcher.uuid)
@@ -138,7 +138,7 @@ export class IntentResolver {
 
     private async onChange(entity: Entity) {
         try {
-            const watchers = await this.intentWatcherDb.list_watchers(
+            const watchers = this.intentWatcherDb.list_watchers(
                 {
                     entity_ref: {
                         uuid: entity.metadata.uuid,
@@ -149,11 +149,15 @@ export class IntentResolver {
                     status: IntentfulStatus.Active
                 }
             )
-            for (let watcher of watchers) {
+            for await (const watcher of watchers) {
                 await this.processActiveWatcher(watcher, entity)
             }
         } catch (e) {
-            this.logger.debug(`Couldn't process onChange for entity with uuid: ${entity.metadata.uuid} and kind: ${entity.metadata.kind} for provider with prefix: ${entity.metadata.provider_prefix} and version: ${entity.metadata.provider_version} due to error: ${e}`)
+            this.logger.debug(`Couldn't process onChange for entity`, {
+                error: e.toString(),
+                stack: e.stack,
+                entity,
+            });
         }
     }
 
@@ -164,7 +168,7 @@ export class IntentResolver {
                 continue
             }
             const [entry_ref, _] = entries[key]
-            const watchers = await this.intentWatcherDb.list_watchers(
+            const watchers = this.intentWatcherDb.list_watchers(
                 {
                     entity_ref: {
                         uuid: entry_ref.entity_reference.uuid,
@@ -175,11 +179,12 @@ export class IntentResolver {
                     status: IntentfulStatus.Active
                 }
             )
-            if (watchers.length !== 0) {
+            const hasWatcher = ! (await watchers[Symbol.asyncIterator]().next()).done;
+            if (hasWatcher) {
                 try {
                     const [, spec] = await this.specDb.get_spec({...entry_ref.provider_reference, ...entry_ref.entity_reference})
                     const [metadata, status] = await this.statusDb.get_status({...entry_ref.provider_reference, ...entry_ref.entity_reference})
-                    this.onChange({ metadata, spec, status })
+                    await this.onChange({ metadata, spec, status })
                 } catch (e) {
                     this.logger.debug(`Failed to process onChange in update active watcher status for entity with uuid: ${entry_ref.entity_reference.uuid} and kind: ${entry_ref.entity_reference.kind} for provider with prefix: ${entry_ref.provider_reference.provider_prefix} and version: ${entry_ref.provider_reference.provider_version} due to error: ${e}`)
                 }
@@ -199,8 +204,8 @@ export class IntentResolver {
     protected async _run(delay: number, watcherExpirySeconds: number) {
         while (true) {
             await timeout(delay)
-            this.clearTerminalStateWatchers(watcherExpirySeconds)
-            this.updateActiveWatchersStatuses()
+            await this.clearTerminalStateWatchers(watcherExpirySeconds)
+            await this.updateActiveWatchersStatuses()
         }
     }
 }

--- a/papiea-engine/src/utils/async.ts
+++ b/papiea-engine/src/utils/async.ts
@@ -1,0 +1,38 @@
+export type AnyIterable<T> = Iterable<T> | AsyncIterable<T>;
+
+export function isAsyncIterable<T>(i: AnyIterable<T>): i is AsyncIterable<T> {
+    return Symbol.asyncIterator in i;
+}
+
+export function iter<T>(i: AnyIterable<T>): AsyncIterable<T> {
+    if (isAsyncIterable(i)) return i;
+    return (async function*() {for await (const v of i) yield v;})();
+}
+
+export async function collect<T>(i: AnyIterable<T>): Promise<T[]> {
+    if (! isAsyncIterable(i)) return Array.from(i);
+
+    const res = [];
+    for await (const v of i) res.push(v);
+    return res;
+}
+
+export async function* map<T, U>(
+    i: AnyIterable<T>, f: (value: T, index: number) => Promise<U>
+): AsyncIterable<U> {
+    let counter = 0;
+    for await (const v of i) {
+        yield await f(v, counter);
+        ++counter;
+    }
+}
+
+export async function* filter<T>(
+    i: AnyIterable<T>, f: (value: T, index: number) => Promise<boolean>
+): AsyncIterable<T> {
+    let counter = 0;
+    for await (const v of i) {
+        if (await f(v, counter)) yield v;
+        ++counter;
+    }
+}


### PR DESCRIPTION
If we have accumulated a lot of intent watchers in the DB due to spec changes,
they may not all fit in memory. Indeed, we have seen OOM issues in production
because of this.

We also saw another OOM issue due to a complete lack of flow control in the
intent_resolver—if we have too many intent watchers to update, the process of
updating them all may take so long that we start the next round, and
progressively run more and more updates in parallel until we run out of memory.

Makes some progress on #679.